### PR TITLE
Alternative Implementation of Scheduler.scheduleTeleport()

### DIFF
--- a/src/main/java/dansplugins/factionsystem/utils/extended/Scheduler.java
+++ b/src/main/java/dansplugins/factionsystem/utils/extended/Scheduler.java
@@ -121,11 +121,16 @@ public class Scheduler {
             try {
                 delay();
             } catch(Exception e) {
+                player.sendMessage(ChatColor.RED + "Something went wrong.");
                 Logger.getInstance().log("Something went wrong running a delayed teleport task.");
                 return;
             }
+
             if (playerHasNotMoved()) {
                 teleportPlayer();
+            }
+            else {
+                player.sendMessage(ChatColor.RED + "Teleport cancelled.");
             }
         }
 


### PR DESCRIPTION
This alternative implementation uses a custom class rather than the scheduler provided by the plugin.

This is intended to be a step in the right direction towards resolving #1322.