### PR TITLE
Fixing factionless players being unable to damage entities

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/DisbandCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/DisbandCommand.java
@@ -89,7 +89,7 @@ public class DisbandCommand extends SubCommand {
         );
         Bukkit.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
-            Logger.getInstance().log("Disband event was cancelled.");
+            Logger.getInstance().debug("Disband event was cancelled.");
             return;
         }
 

--- a/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/ForceCommand.java
@@ -219,7 +219,7 @@ public class ForceCommand extends SubCommand {
         FactionJoinEvent joinEvent = new FactionJoinEvent(faction, player);
         Bukkit.getPluginManager().callEvent(joinEvent);
         if (joinEvent.isCancelled()) {
-            Logger.getInstance().log("Join event was cancelled.");
+            Logger.getInstance().debug("Join event was cancelled.");
             return;
         }
         messageFaction(faction, translate("&a" + getText("HasJoined", player.getName(), faction.getName())));
@@ -262,7 +262,7 @@ public class ForceCommand extends SubCommand {
         FactionKickEvent kickEvent = new FactionKickEvent(faction, target, null); // no kicker so null is used
         Bukkit.getPluginManager().callEvent(kickEvent);
         if (kickEvent.isCancelled()) {
-            Logger.getInstance().log("Kick event was cancelled.");
+            Logger.getInstance().debug("Kick event was cancelled.");
             return;
         }
         if (faction.isOfficer(targetUUID)) {
@@ -434,7 +434,7 @@ public class ForceCommand extends SubCommand {
         final FactionRenameEvent renameEvent = new FactionRenameEvent(faction, oldName, newName);
         Bukkit.getPluginManager().callEvent(renameEvent);
         if (renameEvent.isCancelled()) {
-            Logger.getInstance().log("Rename event was cancelled.");
+            Logger.getInstance().debug("Rename event was cancelled.");
             return;
         }
 

--- a/src/main/java/dansplugins/factionsystem/commands/JoinCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/JoinCommand.java
@@ -55,7 +55,7 @@ public class JoinCommand extends SubCommand {
         FactionJoinEvent joinEvent = new FactionJoinEvent(faction, player);
         Bukkit.getPluginManager().callEvent(joinEvent);
         if (joinEvent.isCancelled()) {
-            Logger.getInstance().log("Join event was cancelled.");
+            Logger.getInstance().debug("Join event was cancelled.");
             return;
         }
         messageFaction(target, translate("&a" + getText("HasJoined", player.getName(), target.getName())));

--- a/src/main/java/dansplugins/factionsystem/commands/KickCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/KickCommand.java
@@ -67,7 +67,7 @@ public class KickCommand extends SubCommand {
         FactionKickEvent kickEvent = new FactionKickEvent(faction, target, player);
         Bukkit.getPluginManager().callEvent(kickEvent);
         if (kickEvent.isCancelled()) {
-            Logger.getInstance().log("Kick event was cancelled.");
+            Logger.getInstance().debug("Kick event was cancelled.");
             return;
         }
         if (faction.isOfficer(targetUUID)) {

--- a/src/main/java/dansplugins/factionsystem/commands/LeaveCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/LeaveCommand.java
@@ -40,7 +40,7 @@ public class LeaveCommand extends SubCommand {
         FactionLeaveEvent leaveEvent = new FactionLeaveEvent(faction, player);
         Bukkit.getPluginManager().callEvent(leaveEvent);
         if (leaveEvent.isCancelled()) {
-            Logger.getInstance().log("Leave event was cancelled.");
+            Logger.getInstance().debug("Leave event was cancelled.");
             return;
         }
 

--- a/src/main/java/dansplugins/factionsystem/commands/RenameCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/RenameCommand.java
@@ -55,7 +55,7 @@ public class RenameCommand extends SubCommand {
         final FactionRenameEvent renameEvent = new FactionRenameEvent(faction, oldName, newName);
         Bukkit.getPluginManager().callEvent(renameEvent);
         if (renameEvent.isCancelled()) {
-            Logger.getInstance().log("Rename event was cancelled.");
+            Logger.getInstance().debug("Rename event was cancelled.");
             return;
         }
 

--- a/src/main/java/dansplugins/factionsystem/commands/VassalizeCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/VassalizeCommand.java
@@ -60,7 +60,7 @@ public class VassalizeCommand extends SubCommand {
         // make sure this vassalization won't result in a vassalization loop
         final int loopCheck = willVassalizationResultInLoop(faction, target);
         if (loopCheck == 1 || loopCheck == 2) {
-            Logger.getInstance().log("Vassalization was cancelled due to potential loop");
+            Logger.getInstance().debug("Vassalization was cancelled due to potential loop");
             return;
         }
         // add faction to attemptedVassalizations

--- a/src/main/java/dansplugins/factionsystem/data/PersistentData.java
+++ b/src/main/java/dansplugins/factionsystem/data/PersistentData.java
@@ -1083,7 +1083,7 @@ public class PersistentData {
             FactionUnclaimEvent unclaimEvent = new FactionUnclaimEvent(holdingFaction, unclaimingPlayer, chunkToRemove.getChunk());
             Bukkit.getPluginManager().callEvent(unclaimEvent);
             if (unclaimEvent.isCancelled()) {
-                Logger.getInstance().log("Unclaim event was cancelled.");
+                Logger.getInstance().debug("Unclaim event was cancelled.");
                 return;
             }
 

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
@@ -60,32 +60,42 @@ public class DamageHandler implements Listener {
      * 4) Players are not in the same faction but are not enemies.
      */
     private void handlePlayerVersusPlayer(Player attacker, Player victim, EntityDamageByEntityEvent event) {
+        Logger.getInstance().log("Handling damage between players.");
 
         // case 1
         if (arePlayersDueling(attacker, victim)) {
+            Logger.getInstance().log("Players are dueling. Ending if necessary.");
             endDuelIfNecessary(attacker, victim, event);
             return;
         }
 
         // case 2
         if (RelationChecker.getInstance().playerNotInFaction(attacker) || RelationChecker.getInstance().playerNotInFaction(victim)) {
+            Logger.getInstance().log("Attacker or victim is not in a faction. Returning.");
             // allow since factionless don't have PVP restrictions
             return;
         }
 
         // case 3
         if (RelationChecker.getInstance().arePlayersInSameFaction(attacker, victim)){
+            Logger.getInstance().log("Players are in the same faction. Handling friendly fire.");
             handleFriendlyFire(event, attacker, victim);
             return;
         }
 
         // case 4
         if (RelationChecker.getInstance().arePlayersFactionsNotEnemies(attacker, victim)) {
+            Logger.getInstance().log("Players factions are not enemies. Handling non-enemy fire.");
             handleNonEnemyFire(event, attacker, victim);
         }
     }
 
     private void handleEntityDamage(Player attacker, EntityDamageByEntityEvent event) {
+        Logger.getInstance().log("Handling entity damage.");
+        if (event.getEntity() instanceof Player) {
+            Logger.getInstance().log("Entity is an instance of a player. Returning.");
+            return;
+        }
         Faction playersFaction = PersistentData.getInstance().getPlayersFaction(attacker.getUniqueId());
         if (playersFaction == null) {
             event.setCancelled(true);

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/DamageHandler.java
@@ -44,7 +44,7 @@ public class DamageHandler implements Listener {
         Player victim = getVictim(event);
 
         if (attacker == null || victim == null) {
-            Logger.getInstance().log("Attacker and/or victim was null in the DamageHandler class.");
+            Logger.getInstance().debug("Attacker and/or victim was null in the DamageHandler class.");
             return;
         }
 
@@ -60,40 +60,40 @@ public class DamageHandler implements Listener {
      * 4) Players are not in the same faction but are not enemies.
      */
     private void handlePlayerVersusPlayer(Player attacker, Player victim, EntityDamageByEntityEvent event) {
-        Logger.getInstance().log("Handling damage between players.");
+        Logger.getInstance().debug("Handling damage between players.");
 
         // case 1
         if (arePlayersDueling(attacker, victim)) {
-            Logger.getInstance().log("Players are dueling. Ending if necessary.");
+            Logger.getInstance().debug("Players are dueling. Ending if necessary.");
             endDuelIfNecessary(attacker, victim, event);
             return;
         }
 
         // case 2
         if (RelationChecker.getInstance().playerNotInFaction(attacker) || RelationChecker.getInstance().playerNotInFaction(victim)) {
-            Logger.getInstance().log("Attacker or victim is not in a faction. Returning.");
+            Logger.getInstance().debug("Attacker or victim is not in a faction. Returning.");
             // allow since factionless don't have PVP restrictions
             return;
         }
 
         // case 3
         if (RelationChecker.getInstance().arePlayersInSameFaction(attacker, victim)){
-            Logger.getInstance().log("Players are in the same faction. Handling friendly fire.");
+            Logger.getInstance().debug("Players are in the same faction. Handling friendly fire.");
             handleFriendlyFire(event, attacker, victim);
             return;
         }
 
         // case 4
         if (RelationChecker.getInstance().arePlayersFactionsNotEnemies(attacker, victim)) {
-            Logger.getInstance().log("Players factions are not enemies. Handling non-enemy fire.");
+            Logger.getInstance().debug("Players factions are not enemies. Handling non-enemy fire.");
             handleNonEnemyFire(event, attacker, victim);
         }
     }
 
     private void handleEntityDamage(Player attacker, EntityDamageByEntityEvent event) {
-        Logger.getInstance().log("Handling entity damage.");
+        Logger.getInstance().debug("Handling entity damage.");
         if (event.getEntity() instanceof Player) {
-            Logger.getInstance().log("Entity is an instance of a player. Returning.");
+            Logger.getInstance().debug("Entity is an instance of a player. Returning.");
             return;
         }
         Faction playersFaction = PersistentData.getInstance().getPlayersFaction(attacker.getUniqueId());

--- a/src/main/java/dansplugins/factionsystem/eventhandlers/JoinHandler.java
+++ b/src/main/java/dansplugins/factionsystem/eventhandlers/JoinHandler.java
@@ -98,16 +98,16 @@ public class JoinHandler implements Listener {
             FactionJoinEvent joinEvent = new FactionJoinEvent(faction, player);
             Bukkit.getPluginManager().callEvent(joinEvent);
             if (joinEvent.isCancelled()) {
-                Logger.getInstance().log("Join event was cancelled.");
+                Logger.getInstance().debug("Join event was cancelled.");
                 return;
             }
             Messenger.getInstance().sendAllPlayersInFactionMessage(faction, String.format(ChatColor.GREEN + "" + Locale.get("HasJoined"), player.getName(), faction.getName()));
             faction.addMember(player.getUniqueId());
             player.sendMessage(ChatColor.GREEN + "" + Locale.get("AssignedToRandomFaction"));
 
-            Logger.getInstance().log(player.getName() + " has been randomly assigned to " + faction.getName() + "!");
+            Logger.getInstance().debug(player.getName() + " has been randomly assigned to " + faction.getName() + "!");
         } else {
-            Logger.getInstance().log("Attempted to assign " + player.getName() + " to a random faction, but no factions are existent.");
+            Logger.getInstance().debug("Attempted to assign " + player.getName() + " to a random faction, but no factions are existent.");
         }
     }
 

--- a/src/main/java/dansplugins/factionsystem/integrators/DynmapIntegrator.java
+++ b/src/main/java/dansplugins/factionsystem/integrators/DynmapIntegrator.java
@@ -59,15 +59,15 @@ public class DynmapIntegrator {
         dynmap = pm.getPlugin("dynmap");
 
         if (!isDynmapPresent()) {
-            Logger.getInstance().log(Locale.get("CannotFindDynmap"));
+            Logger.getInstance().debug(Locale.get("CannotFindDynmap"));
         } else {
             try {
                 dynmapAPI = (DynmapCommonAPI) dynmap; /* Get API */
                 markerAPI = dynmapAPI.getMarkerAPI();
                 initializeMarkerSets();
-                Logger.getInstance().log(Locale.get("DynmapIntegrationSuccessful"));
+                Logger.getInstance().debug(Locale.get("DynmapIntegrationSuccessful"));
             } catch (Exception e) {
-                Logger.getInstance().log(Locale.get("ErrorIntegratingWithDynmap") + e.getMessage());
+                Logger.getInstance().debug(Locale.get("ErrorIntegratingWithDynmap") + e.getMessage());
             }
         }
     }
@@ -139,7 +139,7 @@ public class DynmapIntegrator {
         if (set == null) {
             set = markerAPI.createMarkerSet(getDynmapPluginSetId(markerLabel), getDynmapPluginLayer(), null, false);
             if (set == null) {
-                Logger.getInstance().log(Locale.get("ErrorCreatingMarkerSet") + ": markerLabel = " + markerLabel);
+                Logger.getInstance().debug(Locale.get("ErrorCreatingMarkerSet") + ": markerLabel = " + markerLabel);
                 return set;
             }
         }

--- a/src/main/java/dansplugins/factionsystem/objects/helper/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/helper/FactionFlags.java
@@ -197,21 +197,21 @@ public class FactionFlags {
 
     public Object getFlag(String flag) {
         if (!isFlag(flag)) {
-            Logger.getInstance().log(String.format("[DEBUG] Flag '%s' was not found!", flag));
+            Logger.getInstance().debug(String.format("[DEBUG] Flag '%s' was not found!", flag));
             return false;
         }
 
         if (integerValues.containsKey(flag)) {
-            Logger.getInstance().log(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, integerValues.get(flag)));
+            Logger.getInstance().debug(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, integerValues.get(flag)));
             return integerValues.get(flag);
         } else if (booleanValues.containsKey(flag)) {
-            Logger.getInstance().log(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, booleanValues.get(flag)));
+            Logger.getInstance().debug(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, booleanValues.get(flag)));
             return booleanValues.get(flag);
         } else if (doubleValues.containsKey(flag)) {
-            Logger.getInstance().log(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, doubleValues.get(flag)));
+            Logger.getInstance().debug(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, doubleValues.get(flag)));
             return doubleValues.get(flag);
         } else if (stringValues.containsKey(flag)) {
-            Logger.getInstance().log(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, stringValues.get(flag)));
+            Logger.getInstance().debug(String.format("[DEBUG] Flag '%s' was found! Value: '%s'", flag, stringValues.get(flag)));
             return stringValues.get(flag);
         }
         return null;

--- a/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
+++ b/src/main/java/dansplugins/factionsystem/utils/InteractionAccessChecker.java
@@ -77,8 +77,8 @@ public class InteractionAccessChecker {
         boolean allyInteractionAllowed = (boolean) chunkHolder.getFlags().getFlag("alliesCanInteractWithLand");
         boolean vassalageTreeInteractionAllowed = (boolean) chunkHolder.getFlags().getFlag("vassalageTreeCanInteractWithLand");
 
-        Logger.getInstance().log("allyInteractionAllowed: " + allyInteractionAllowed);
-        Logger.getInstance().log("vassalageTreeInteractionAllowed: " + vassalageTreeInteractionAllowed);
+        Logger.getInstance().debug("allyInteractionAllowed: " + allyInteractionAllowed);
+        Logger.getInstance().debug("vassalageTreeInteractionAllowed: " + vassalageTreeInteractionAllowed);
 
         boolean allowed = allyInteractionAllowed && isAlly;
 

--- a/src/main/java/dansplugins/factionsystem/utils/Logger.java
+++ b/src/main/java/dansplugins/factionsystem/utils/Logger.java
@@ -25,9 +25,29 @@ public class Logger {
         return instance;
     }
 
-    public void log(String message) {
+    /**
+     * Log a debug message if the debug flag is enabled.
+     * @param message The message to log.
+     */
+    public void debug(String message) {
         if (MedievalFactions.getInstance().isDebugEnabled()) {
-            MedievalFactions.getInstance().getLogger().log(Level.INFO, "[Medieval Factions] " + message);
+            MedievalFactions.getInstance().getLogger().log(Level.INFO, "[Medieval Factions DEBUG] " + message);
         }
+    }
+
+    /**
+     * Log a message to the console.
+     * @param message The message to log.
+     */
+    public void print(String message) {
+        MedievalFactions.getInstance().getLogger().log(Level.INFO, "[Medieval Factions] " + message);
+    }
+
+    /**
+     * Log an error to the console.
+     * @param message The message to log.
+     */
+    public void error(String message) {
+        MedievalFactions.getInstance().getLogger().log(Level.SEVERE, "[Medieval Factions ERROR] " + message);
     }
 }

--- a/src/main/java/dansplugins/factionsystem/utils/PlayerTeleporter.java
+++ b/src/main/java/dansplugins/factionsystem/utils/PlayerTeleporter.java
@@ -18,13 +18,13 @@ public class PlayerTeleporter {
     }
 
     public boolean teleportPlayer(Player player, Location location) {
-        Logger.getInstance().log("Attempting to teleport " + player.getName() + " to " + location.toString());
+        Logger.getInstance().debug("Attempting to teleport " + player.getName() + " to " + location.toString());
         boolean success = player.teleport(location);
         if (success) {
-            Logger.getInstance().log("Successfully teleported " + player.getName());
+            Logger.getInstance().debug("Successfully teleported " + player.getName());
         }
         else {
-            Logger.getInstance().log("Failed to teleport " + player.getName());
+            Logger.getInstance().debug("Failed to teleport " + player.getName());
         }
         return success;
     }

--- a/src/main/java/dansplugins/factionsystem/utils/extended/Scheduler.java
+++ b/src/main/java/dansplugins/factionsystem/utils/extended/Scheduler.java
@@ -39,39 +39,39 @@ public class Scheduler {
     }
 
     public void scheduleAutosave() {
-        Logger.getInstance().log(Locale.get("SchedulingHourlyAutoSave"));
+        Logger.getInstance().debug(Locale.get("SchedulingHourlyAutoSave"));
         int delay = 60 * 60; // 1 hour
         int secondsUntilRepeat = 60 * 60; // 1 hour
         Bukkit.getScheduler().scheduleSyncRepeatingTask(MedievalFactions.getInstance(), new Runnable() {
             @Override
             public void run() {
-                Logger.getInstance().log(Locale.get("HourlySaveAlert"));
+                Logger.getInstance().debug(Locale.get("HourlySaveAlert"));
                 PersistentData.getInstance().getLocalStorageService().save();
             }
         }, delay * 20, secondsUntilRepeat * 20);
     }
 
     public void schedulePowerIncrease() {
-        Logger.getInstance().log(Locale.get("SchedulingPowerIncrease"));
+        Logger.getInstance().debug(Locale.get("SchedulingPowerIncrease"));
         int delay = MedievalFactions.getInstance().getConfig().getInt("minutesBeforeInitialPowerIncrease") * 60; // 30 minutes
         int secondsUntilRepeat = MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerIncreases") * 60; // 1 hour
         Bukkit.getScheduler().scheduleSyncRepeatingTask(MedievalFactions.getInstance(), new Runnable() {
             @Override
             public void run() {
-                Logger.getInstance().log(String.format((Locale.get("AlertIncreasingThePowerOfEveryPlayer")) + "%n", MedievalFactions.getInstance().getConfig().getInt("powerIncreaseAmount"), MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerIncreases")));
+                Logger.getInstance().debug(String.format((Locale.get("AlertIncreasingThePowerOfEveryPlayer")) + "%n", MedievalFactions.getInstance().getConfig().getInt("powerIncreaseAmount"), MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerIncreases")));
                 PersistentData.getInstance().initiatePowerIncreaseForAllPlayers();
             }
         }, delay * 20L, secondsUntilRepeat * 20L);
     }
 
     public void schedulePowerDecrease() {
-        Logger.getInstance().log(Locale.get("SchedulingPowerDecrease"));
+        Logger.getInstance().debug(Locale.get("SchedulingPowerDecrease"));
         int delay = MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerDecreases") * 60;
         int secondsUntilRepeat = MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerDecreases") * 60;
         Bukkit.getScheduler().scheduleSyncRepeatingTask(MedievalFactions.getInstance(), new Runnable() {
             @Override
             public void run() {
-                Logger.getInstance().log(String.format((Locale.get("AlertDecreasingThePowerOfInactivePlayers")) + "%n", MedievalFactions.getInstance().getConfig().getInt("powerDecreaseAmount"), MedievalFactions.getInstance().getConfig().getInt("minutesBeforePowerDecrease"), MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerDecreases")));
+                Logger.getInstance().debug(String.format((Locale.get("AlertDecreasingThePowerOfInactivePlayers")) + "%n", MedievalFactions.getInstance().getConfig().getInt("powerDecreaseAmount"), MedievalFactions.getInstance().getConfig().getInt("minutesBeforePowerDecrease"), MedievalFactions.getInstance().getConfig().getInt("minutesBetweenPowerDecreases")));
 
                 PersistentData.getInstance().decreasePowerForInactivePlayers();
 
@@ -131,7 +131,7 @@ public class Scheduler {
                 delay();
             } catch(Exception e) {
                 player.sendMessage(ChatColor.RED + "Something went wrong.");
-                Logger.getInstance().log("Something went wrong running a delayed teleport task.");
+                Logger.getInstance().debug("Something went wrong running a delayed teleport task.");
                 return;
             }
 


### PR DESCRIPTION
After the PVP checks, all damage to entities caused by factionless players was being cancelled so as to prevent factionless players looting entities like armorstands. I've added a player check so that players are exempt from the cancellation.

closes #1353