### PR TITLE
Declare War Command Arg Requirement Fix

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/DeclareWarCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/DeclareWarCommand.java
@@ -51,7 +51,7 @@ public class DeclareWarCommand extends SubCommand {
         ArgumentParser argumentParser = new ArgumentParser();
         ArrayList<String> doubleQuoteArgs = argumentParser.getArgumentsInsideDoubleQuotes(args);
 
-        if (doubleQuoteArgs.size() < 2) {
+        if (doubleQuoteArgs.size() == 0) {
             player.sendMessage(translate("&c" + "Usage: /mf declarewar \"faction\" (quotation marks are required)"));
             return;
         }

--- a/src/main/java/dansplugins/factionsystem/commands/abs/SubCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/abs/SubCommand.java
@@ -24,7 +24,6 @@ import dansplugins.factionsystem.services.LocalLocaleService;
 
 /**
  * @author Callum Johnson
- * @author Daniel McCoy Stephenson
  * @since 05/05/2021 - 12:18
  */
 public abstract class SubCommand implements ColorTranslator {


### PR DESCRIPTION
The declarewar command was requiring two arguments instead of one, even though players are supposed to give just one.