### PR TITLE
Fixed players being unable to set faction flags when the factionsCanSetPrefixColors config option was set to false.

### DIFF
--- a/src/main/java/dansplugins/factionsystem/objects/helper/FactionFlags.java
+++ b/src/main/java/dansplugins/factionsystem/objects/helper/FactionFlags.java
@@ -130,7 +130,7 @@ public class FactionFlags {
             return;
         }
 
-        if (!configService.getBoolean("factionsCanSetPrefixColors")) {
+        if (flag.equals("prefixColor") && !configService.getBoolean("factionsCanSetPrefixColors")) {
             player.sendMessage("Players can't set prefix colors.");
             return;
         }


### PR DESCRIPTION
Players should now be able to set faction flags even when 'factionsCanSetPrefixColors' is disabled.

closes #1446