### PR TITLE
YML Translation System By Default

### DIFF
--- a/src/main/java/dansplugins/factionsystem/services/ConfigService.java
+++ b/src/main/java/dansplugins/factionsystem/services/ConfigService.java
@@ -158,7 +158,7 @@ public class ConfigService {
             getConfig().set("bonusPowerEnabled", true);
         }
         if (!getConfig().isBoolean("useNewLanguageFile")) {
-            getConfig().set("useNewLanguageFile", false);
+            getConfig().set("useNewLanguageFile", true);
         }
         if (!getConfig().isDouble("powerLostOnDeath")) {
             getConfig().set("powerLostOnDeath", 1.0);
@@ -321,7 +321,7 @@ public class ConfigService {
         getConfig().set("powerGainedOnKill", 1.0);
         getConfig().set("teleportDelay", 3);
         getConfig().set("factionless", "FactionLess");
-        getConfig().set("useNewLanguageFile", false);
+        getConfig().set("useNewLanguageFile", true);
         getConfig().set("secondsBeforeInitialAutosave", 60);
         getConfig().set("secondsBetweenAutosaves", 60);
         getConfig().options().copyDefaults(true);


### PR DESCRIPTION
This PR transitions us into using the YML system by default instead of the TSV system for translations.