### PR TITLE
Removed link to deleted issue

### DIFF
--- a/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
+++ b/src/main/java/dansplugins/factionsystem/commands/UnclaimCommand.java
@@ -55,7 +55,6 @@ public class UnclaimCommand extends SubCommand {
                     , "UnClaimed", false);
             return;
         }
-        // https://github.com/dmccoystephenson/Medieval-Factions/issues/836
         int radius = getIntSafe(args[0], 1);
         if (radius <= 0) {
             radius = 1;


### PR DESCRIPTION
This link points to a delted issue, which because it's deleted, can't be seen anymore.