### PR TITLE
Fixed misleading translation

### DIFF
--- a/src/main/resources/de.tsv
+++ b/src/main/resources/de.tsv
@@ -96,7 +96,7 @@ AssignedToRandomFaction	Du wurdest einer zufälligen Faction zugeordnet
 AttemptedAlliance	Bündnisangebot an %s gesendet
 AttemptedPeace	Friedensangebot an %s gesendet
 AtWarWith	Im Krieg mit. %s
-AutoclaimToggled	Autoclaim aktiviert.
+AutoclaimToggled	Autoclaim umgeschalten.
 BlockAlreadyLocked	Dieser Block ist bereits gesichert
 BlockIsNotLocked	Dieser Block ist noch nicht gesichert
 BlockIsPartOfGateMustRemoveGate	Dieser Block ist Teil von Gate '%s'. Du musst zuerst das Gate removen!


### PR DESCRIPTION
"aktiviert" translates into "activated". If you would toggle autoclaim off you would still get the feedback that autoclaim is now activated. This is misleading. The word "umgeschalten" fits better because it actually means toggling.