### PR TITLE
Removed 'mustBeOfficerToX' flags since they weren't being used.

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,8 +65,6 @@ factions:
   factionHomeTeleportDelay: 5
   defaults:
     flags:
-      mustBeOfficerToManageLand: true
-      mustBeOfficierToInviteOthers: true
       alliesCanInteractWithLand: false
       vassalageTreeCanInteractWithLand: false
       neutral: false


### PR DESCRIPTION
Some unused flags have been removed. At least, they didn't show up in the repository when I searched w/ CTRL+SHIFT+F.