### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @alyphen
-* @dmccoystephenson
+* @alyphen @dmccoystephenson


### PR DESCRIPTION
Codeowners for each pattern should be specified on a single line.
Later patterns take precedence over previous patterns so you can override previous directives.