### PR TITLE
Added player permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -356,6 +356,70 @@ permissions:
     - mf.force.claim
     - mf.force.unclaim
     - mf.force.flag
+  mf.player:
+    description: Player permission
+    default: true
+    children:
+      - mf.help
+      - mf.ally
+      - mf.breakalliance
+      - mf.create
+      - mf.declarewar
+      - mf.invite
+      - mf.join
+      - mf.addlaw
+      - mf.laws
+      - mf.removelaw
+      - mf.makepeace
+      - mf.info
+      - mf.info.other
+      - mf.members
+      - mf.role.view
+      - mf.role.list
+      - mf.role.setpermission
+      - mf.role.set
+      - mf.role.create
+      - mf.role.delete
+      - mf.role.setdefault
+      - mf.role.rename
+      - mf.list
+      - mf.claim
+      - mf.claim.auto
+      - mf.claim.circle
+      - mf.claim.fill
+      - mf.claim.check
+      - mf.unclaim
+      - mf.unclaimall
+      - mf.power
+      - mf.power.view.other
+      - mf.who
+      - mf.disband
+      - mf.invoke
+      - mf.leave
+      - mf.rename
+      - mf.desc
+      - mf.vassalize
+      - mf.swearfealty
+      - mf.declareindependence
+      - mf.grantindependence
+      - mf.lock
+      - mf.unlock
+      - mf.kick
+      - mf.map
+      - mf.sethome
+      - mf.home
+      - mf.gate
+      - mf.flag.list
+      - mf.flag.set
+      - mf.relationship.view
+      - mf.relationship.add
+      - mf.relationship.remove
+      - mf.duel
+      - mf.accessors.list
+      - mf.accessors.add
+      - mf.grantaccess
+      - mf.accessors.remove
+      - mf.revokeaccess
   mf.admin:
     description: Admin permission
     default: op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -358,7 +358,7 @@ permissions:
     - mf.force.flag
   mf.player:
     description: Player permission
-    default: true
+    default: false
     children:
       - mf.help
       - mf.ally

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -360,9 +360,9 @@ permissions:
     description: Admin permission
     default: op
     children:
-    - mf.force.*
-    - mf.bypass
-    - mf.relationship.view
-    - mf.relationship.add
-    - mf.relationship.remove
-    - mf.power.set
+      - mf.force.*
+      - mf.bypass
+      - mf.relationship.view
+      - mf.relationship.add
+      - mf.relationship.remove
+      - mf.power.set


### PR DESCRIPTION
I noticed that admins had an easy permission that could be given, I thought that having the same option for players would make using the plugin easier. It's default set to false to not override anything, but it'll still be an option for server owners to give in their permissions plugin.