### PR TITLE
Display - Relationships in Info Command (Redone)

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/info/MfFactionInfoCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/info/MfFactionInfoCommand.kt
@@ -146,6 +146,28 @@ class MfFactionInfoCommand(private val plugin: MedievalFactions) : CommandExecut
                         }
                     )
                 }
+
+                // send vassals information
+                val vassals = plugin.services.factionRelationshipService.getVassals(faction.id).mapNotNull(factionService::getFaction)
+                if (vassals.isNotEmpty()) {
+                    sender.sendMessage("${BukkitChatColor.WHITE}${plugin.language["CommandFactionInfoVassalsTitle"]}")
+                    sender.sendMessage("${BukkitChatColor.GRAY}" + vassals.joinToString(transform = MfFaction::name))
+                }
+
+                // send allies information
+                val allies = plugin.services.factionRelationshipService.getAllies(faction.id).mapNotNull(factionService::getFaction)
+                if (allies.isNotEmpty()) {
+                    sender.sendMessage("${BukkitChatColor.WHITE}${plugin.language["CommandFactionInfoAlliesTitle"]}")
+                    sender.sendMessage("${BukkitChatColor.GRAY}" + allies.joinToString(transform = MfFaction::name))
+                }
+
+                // send wars information
+                val atWarWith = plugin.services.factionRelationshipService.getFactionsAtWarWith(faction.id).mapNotNull(factionService::getFaction)
+                if (atWarWith.isNotEmpty()) {
+                    sender.sendMessage("${BukkitChatColor.WHITE}${plugin.language["CommandFactionInfoEnemiesTitle"]}")
+                    sender.sendMessage("${BukkitChatColor.GRAY}" + atWarWith.joinToString(transform = MfFaction::name))
+                }
+
                 factionService.fields
                     .filter { field -> field.isVisibleFor(faction.id.value, senderMfPlayer?.id?.value ?: return@filter false) }
                     .forEach { field ->

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1020,3 +1020,6 @@ TeleportationCancelled=Teleportation abgebrochen.
 PowerIncreased=Du fühlst dich wieder stärker. Dein macht ist auf {0} gestiegen.
 CommandFactionDisbandOthersNoPermission=Du hast nicht die Erlaubnis, andere Fraktionen aufzulösen.
 CommandFactionDisbandSpecifiedFactionNotFound=Die angegebene Fraktion wurde nicht gefunden.
+CommandFactionInfoVassalsTitle=Vasallen:
+CommandFactionInfoAlliesTitle=Verbündete:
+CommandFactionInfoEnemiesTitle=Feinde:

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1020,3 +1020,6 @@ TeleportationCancelled=Teleportation cancelled.
 PowerIncreased=You feel stronger. Your power has increased by {0}.
 CommandFactionDisbandOthersNoPermission=You don''t have permission to disband other factions.
 CommandFactionDisbandSpecifiedFactionNotFound=The specified faction wasn''t found.
+CommandFactionInfoVassalsTitle=Vassals:
+CommandFactionInfoAlliesTitle=Allies:
+CommandFactionInfoEnemiesTitle=Enemies:

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1020,3 +1020,6 @@ TeleportationCancelled=Teleportation cancelled.
 PowerIncreased=You feel stronger. Your power has increased by {0}.
 CommandFactionDisbandOthersNoPermission=You don''t have permission to disband other factions.
 CommandFactionDisbandSpecifiedFactionNotFound=The specified faction wasn''t found.
+CommandFactionInfoVassalsTitle=Vassals:
+CommandFactionInfoAlliesTitle=Allies:
+CommandFactionInfoEnemiesTitle=Enemies:

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1020,3 +1020,6 @@ TeleportationCancelled=Téléportation annulée.
 PowerIncreased=Vous vous sentez plus fort. Votre pouvoir a augmenté de {0}.
 CommandFactionDisbandOthersNoPermission=Vous n''avez pas la permission de dissoudre d''autres factions.
 CommandFactionDisbandSpecifiedFactionNotFound=La faction spécifiée n''a pas été trouvée.
+CommandFactionInfoVassalsTitle=Vassas:
+CommandFactionInfoAlliesTitle=Alliés:
+CommandFactionInfoEnemiesTitle=Ennemis:


### PR DESCRIPTION
The changes in this PR allow players to view the vassals, allies and enemies of a faction through the 'mf info' command.

closes #1600

German and French translations are still required for the following:
```
CommandFactionInfoVassalsTitle=Vassals:
CommandFactionInfoAlliesTitle=Allies:
CommandFactionInfoEnemiesTitle=Enemies:
```