### PR TITLE
Create language files if nonexistent

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
@@ -18,25 +18,25 @@ class Language(plugin: MedievalFactions, private val language: String) {
         }
 
         val enUsFilename = "lang/lang_en_US.properties"
-        var enUsFile = File(enUsFilename)
+        val enUsFile = File(enUsFilename)
         if (!enUsFile.exists()) {
             plugin.saveResource(enUsFilename, false)
         }
 
         val enGbFilename = "lang/lang_en_GB.properties"
-        var enGbFile = File(enGbFilename)
+        val enGbFile = File(enGbFilename)
         if (!enGbFile.exists()) {
             plugin.saveResource(enGbFilename, false)
         }
 
         val frFrFilename = "lang/lang_fr_FR.properties"
-        var frFrFile = File(frFrFilename)
+        val frFrFile = File(frFrFilename)
         if (!frFrFile.exists()) {
             plugin.saveResource(frFrFilename, false)
         }
 
         val deDeFilename = "lang/lang_de_DE.properties"
-        var deDeFile = File(deDeFilename)
+        val deDeFile = File(deDeFilename)
         if (!deDeFile.exists()) {
             plugin.saveResource(deDeFilename, false)
         }

--- a/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
@@ -40,7 +40,6 @@ class Language(plugin: MedievalFactions, private val language: String) {
         if (!de_de_file.exists()) {
             plugin.saveResource(de_de_filename, false)
         }
-        plugin.saveResource(de_de_filename, false)
 
         val externalUrls = arrayOf(languageFolder.toURI().toURL())
         val externalClassLoader = URLClassLoader(externalUrls)

--- a/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
@@ -40,7 +40,7 @@ class Language(plugin: MedievalFactions, private val language: String) {
         if (!de_de_file.exists()) {
             plugin.saveResource(de_de_filename, false)
         }
-        plugin.saveResource("lang/lang_de_DE.properties", false)
+        plugin.saveResource(de_de_filename, false)
 
         val externalUrls = arrayOf(languageFolder.toURI().toURL())
         val externalClassLoader = URLClassLoader(externalUrls)

--- a/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
@@ -17,28 +17,28 @@ class Language(plugin: MedievalFactions, private val language: String) {
             languageFolder.mkdirs()
         }
 
-        val en_us_filename = "lang/lang_en_US.properties"
-        var en_us_file = File(en_us_filename)
-        if (!en_us_file.exists()) {
-            plugin.saveResource(en_us_filename, false)
+        val enUsFilename = "lang/lang_en_US.properties"
+        var enUsFile = File(enUsFilename)
+        if (!enUsFile.exists()) {
+            plugin.saveResource(enUsFilename, false)
         }
 
-        val en_gb_filename = "lang/lang_en_GB.properties"
-        var en_gb_file = File(en_gb_filename)
-        if (!en_gb_file.exists()) {
-            plugin.saveResource(en_gb_filename, false)
+        val enGbFilename = "lang/lang_en_GB.properties"
+        var enGbFile = File(enGbFilename)
+        if (!enGbFile.exists()) {
+            plugin.saveResource(enGbFilename, false)
         }
 
-        val fr_fr_filename = "lang/lang_fr_FR.properties"
-        var fr_fr_file = File(fr_fr_filename)
-        if (!fr_fr_file.exists()) {
-            plugin.saveResource(fr_fr_filename, false)
+        val frFrFilename = "lang/lang_fr_FR.properties"
+        var frFrFile = File(frFrFilename)
+        if (!frFrFile.exists()) {
+            plugin.saveResource(frFrFilename, false)
         }
 
-        val de_de_filename = "lang/lang_de_DE.properties"
-        var de_de_file = File(de_de_filename)
-        if (!de_de_file.exists()) {
-            plugin.saveResource(de_de_filename, false)
+        val deDeFilename = "lang/lang_de_DE.properties"
+        var deDeFile = File(deDeFilename)
+        if (!deDeFile.exists()) {
+            plugin.saveResource(deDeFilename, false)
         }
 
         val externalUrls = arrayOf(languageFolder.toURI().toURL())

--- a/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/lang/Language.kt
@@ -15,11 +15,33 @@ class Language(plugin: MedievalFactions, private val language: String) {
         val languageFolder = File(plugin.dataFolder, "lang")
         if (!languageFolder.exists()) {
             languageFolder.mkdirs()
-            plugin.saveResource("lang/lang_en_US.properties", false)
-            plugin.saveResource("lang/lang_en_GB.properties", false)
-            plugin.saveResource("lang/lang_fr_FR.properties", false)
-            plugin.saveResource("lang/lang_de_DE.properties", false)
         }
+
+        val en_us_filename = "lang/lang_en_US.properties"
+        var en_us_file = File(en_us_filename)
+        if (!en_us_file.exists()) {
+            plugin.saveResource(en_us_filename, false)
+        }
+
+        val en_gb_filename = "lang/lang_en_GB.properties"
+        var en_gb_file = File(en_gb_filename)
+        if (!en_gb_file.exists()) {
+            plugin.saveResource(en_gb_filename, false)
+        }
+
+        val fr_fr_filename = "lang/lang_fr_FR.properties"
+        var fr_fr_file = File(fr_fr_filename)
+        if (!fr_fr_file.exists()) {
+            plugin.saveResource(fr_fr_filename, false)
+        }
+
+        val de_de_filename = "lang/lang_de_DE.properties"
+        var de_de_file = File(de_de_filename)
+        if (!de_de_file.exists()) {
+            plugin.saveResource(de_de_filename, false)
+        }
+        plugin.saveResource("lang/lang_de_DE.properties", false)
+
         val externalUrls = arrayOf(languageFolder.toURI().toURL())
         val externalClassLoader = URLClassLoader(externalUrls)
         val externalResourceBundle = ResourceBundle.getBundle(


### PR DESCRIPTION
The changes in this PR make the plugin create each individual language file if it is not found, rather than only creating the language files if the 'lang' folder is not found.

closes #1641 

This still needs to be tested so I'm marking it as a draft PR for now.