### PR TITLE
Fix - Only Autoclaim With Permission

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
@@ -38,7 +38,7 @@ class PlayerMoveListener(private val plugin: MedievalFactions) : Listener {
                 if (newChunkFaction == null && playerFaction.autoclaim) {
                     val playerRole = playerFaction.getRole(mfPlayer.id) ?: return@Runnable
                     val claimPermissionValue = playerRole.getPermissionValue(plugin.factionPermissions.claim) ?: return@Runnable
-                    if (!claimPermissionValue) return@Runnable
+                    if (!claimPermissionValue || !event.player.hasPermission("mf.claim")) return@Runnable
 
                     if (plugin.config.getBoolean("factions.limitLand") && claimService.getClaims(playerFaction.id).size + 1 > playerFaction.power) {
                         event.player.sendMessage("$RED${plugin.language["AutoclaimPowerLimitReached"]}")

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
@@ -36,6 +36,10 @@ class PlayerMoveListener(private val plugin: MedievalFactions) : Listener {
             val playerFaction = factionService.getFaction(mfPlayer.id)
             if (playerFaction != null) {
                 if (newChunkFaction == null && playerFaction.autoclaim) {
+                    val playerRole = playerFaction.getRole(mfPlayer.id) ?: return@Runnable
+                    val claimPermissionValue = playerRole.getPermissionValue(plugin.factionPermissions.claim) ?: return@Runnable
+                    if (!claimPermissionValue) return@Runnable
+
                     if (plugin.config.getBoolean("factions.limitLand") && claimService.getClaims(playerFaction.id).size + 1 > playerFaction.power) {
                         event.player.sendMessage("$RED${plugin.language["AutoclaimPowerLimitReached"]}")
                         val updatedFaction = factionService.save(playerFaction.copy(autoclaim = false)).onFailure {


### PR DESCRIPTION
This fixes players being able to autoclaim even if their role doesn't have the 'claim' permission.

closes #1671 