### PR TITLE
Fix - Prevent players from editing their role's permission to edit their own role's permissions.

### DIFF
--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1064,4 +1064,4 @@ CommandFactionAddMemberFailedToSaveFaction=Fraktion konnte nicht gespeichert wer
 CommandFactionAddMemberUnknownNewPlayerFaction=Unbekanntes neues Mitglied
 CommandFactionAddMemberSuccess=Dieser Spieler ist jetzt Mitglied der angegebenen Fraktion.
 CommandFactionHelpAddMember=/faction addmember <player> <faction> - Fügt zwangsweise ein Mitglied zu einer Fraktion hinzu.
-CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Sie können die Berechtigung Ihrer Rolle nicht ändern, um die Berechtigungen Ihrer eigenen Rolle zu ändern.
+CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Du kannst die Berechtigung deiner Rolle nicht ändern, um die Berechtigungen deiner eigenen Rolle zu ändern.

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1064,3 +1064,4 @@ CommandFactionAddMemberFailedToSaveFaction=Fraktion konnte nicht gespeichert wer
 CommandFactionAddMemberUnknownNewPlayerFaction=Unbekanntes neues Mitglied
 CommandFactionAddMemberSuccess=Dieser Spieler ist jetzt Mitglied der angegebenen Fraktion.
 CommandFactionHelpAddMember=/faction addmember <player> <faction> - Fügt zwangsweise ein Mitglied zu einer Fraktion hinzu.
+CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Sie können die Berechtigung Ihrer Rolle nicht ändern, um die Berechtigungen Ihrer eigenen Rolle zu ändern.

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1066,3 +1066,4 @@ CommandFactionInfoVassalsTitle=Vassals:
 CommandFactionInfoAlliesTitle=Allies:
 CommandFactionInfoEnemiesTitle=Enemies:
 BlockNotLocked=That block is not locked.
+CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=You cannot modify your role''s permission to modify your own role''s permissions.

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1066,3 +1066,4 @@ CommandFactionHelpAddMember=/faction addmember <player> <faction> - Forcefully a
 CommandFactionInfoVassalsTitle=Vassals:
 CommandFactionInfoAlliesTitle=Allies:
 CommandFactionInfoEnemiesTitle=Enemies:
+CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=You cannot modify your role''s permission to modify your own role''s permissions.

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1066,3 +1066,4 @@ CommandFactionAddMemberUnknownNewPlayerFaction=Nouveau membre inconnu
 CommandFactionAddMemberSuccess=Ce joueur est maintenant membre de la faction spécifiée.
 CommandFactionHelpAddMember=/faction addmember <joueur> <faction> - Ajoute de force un membre à une faction.
 BlockNotLocked=Ce bloc n'est pas verrouillé.
+CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Vous ne pouvez pas modifier les autorisations de votre r\u00e9le pour modifier les autorisations de votre propre r\u00e9le.


### PR DESCRIPTION
This is a bit convoluted, but basically players are able to deny themselves permission to edit their own role's permission via the 'setpermission' command. If the player is the sole owner of a faction, this can lock them out. This prevents players from doing that.

closes #1662 