### PR TITLE
More Custom Charts

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -248,7 +248,8 @@ class MedievalFactions : JavaPlugin() {
                 factionService.factions
                     .map {
                         claimService.getClaims(it.id).size
-                    }.average().toString()
+                    }
+                    .average().toInt().toString()
             }
         )
         metrics.addCustomChart(
@@ -284,7 +285,7 @@ class MedievalFactions : JavaPlugin() {
             }
         )
         metrics.addCustomChart(
-            SimplePie("allowNeutrality") {
+            SimplePie("allow_neutrality") {
                 config.getBoolean("factions.allowNeutrality").toString()
             }
         )

--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -141,12 +141,6 @@ class MedievalFactions : JavaPlugin() {
         saveConfig()
 
         language = Language(this, config.getString("language") ?: "en-US")
-        val metrics = Metrics(this, 8929)
-        metrics.addCustomChart(
-            SimplePie("language_used") {
-                config.getString("language")
-            }
-        )
 
         Class.forName("org.h2.Driver")
         val hikariConfig = HikariConfig()
@@ -237,6 +231,63 @@ class MedievalFactions : JavaPlugin() {
             dynmapService
         )
         setupRpkLockService()
+
+        val metrics = Metrics(this, 8929)
+        metrics.addCustomChart(
+            SimplePie("language_used") {
+                config.getString("language")
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("database_dialect") {
+                config.getString("database.dialect")
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("average_claims") {
+                factionService.factions
+                    .map {
+                        claimService.getClaims(it.id).size
+                    }.average().toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("total_claims") {
+                factionService.factions.sumOf {
+                    claimService.getClaims(it.id).size
+                }.toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("initial_power") {
+                config.getDouble("players.initialPower").toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("max_power") {
+                config.getDouble("players.maxPower").toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("hours_to_reach_max_power") {
+                config.getDouble("players.hoursToReachMaxPower").toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("hours_to_reach_min_power") {
+                config.getDouble("players.hoursToReachMinPower").toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("limit_land") {
+                config.getBoolean("factions.limitLand").toString()
+            }
+        )
+        metrics.addCustomChart(
+            SimplePie("allowNeutrality") {
+                config.getBoolean("factions.allowNeutrality").toString()
+            }
+        )
 
         if (config.getBoolean("migrateMf4")) {
             migrator.migrate()


### PR DESCRIPTION
Added custom bStats charts for the following:
- database dialect
- average claims
- total claims
- initial power
- max power
- hours to reach max power
- hours to reach min power
- limit land
- allow neutrality

These can be seen on the bStats page.
https://bstats.org/plugin/bukkit/Medieval%20Factions/8929

closes #1696 