### PR TITLE
Allowed bypassed players to set their own role.

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/role/MfFactionRoleSetCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/role/MfFactionRoleSetCommand.kt
@@ -48,7 +48,7 @@ class MfFactionRoleSetCommand(private val plugin: MedievalFactions) : CommandExe
                         plugin.logger.log(SEVERE, "Failed to save target player: ${it.reason.message}", it.reason.cause)
                         return@Runnable
                     }
-                if (mfPlayer.id.value == targetMfPlayer.id.value) {
+                if (mfPlayer.id.value == targetMfPlayer.id.value && !mfPlayer.isBypassEnabled) {
                     sender.sendMessage("$RED${plugin.language["CommandFactionRoleSetCannotSetOwnRole"]}")
                     return@Runnable
                 }


### PR DESCRIPTION
Players who are in bypass mode can now set their own role. This allows an operator who has accidentally left their faction to forcefully regain control of their faction.

closes #1701 