### PR TITLE
Added unique name check to `set name` command.

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
@@ -108,6 +108,10 @@ class MfFactionSetNameCommand(private val plugin: MedievalFactions) : CommandExe
                     player.sendMessage("$RED${plugin.language["CommandFactionSetNameNoFactionPermission"]}")
                     return@Runnable
                 }
+                if (factionService.getFaction(name) != null) {
+                    player.sendMessage("$RED${plugin.language["CommandFactionSetNameFactionAlreadyExists"]}")
+                    return@Runnable
+                }
                 val updatedFaction = factionService.save(faction.copy(name = name)).onFailure {
                     player.sendMessage("$RED${plugin.language["CommandFactionSetNameFailedToSaveFaction"]}")
                     plugin.logger.log(Level.SEVERE, "Failed to save faction: ${it.reason.message}", it.reason.cause)

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -513,6 +513,7 @@ CommandFactionSetNameNameTooLong=Dein Fraktionsname darf nicht länger als {0} Ze
 CommandFactionSetNameNoFactionPermission=Deine Rolle in dieser Fraktion gibt dir nicht die Erlaubnis, ihren Namen zu ändern.
 CommandFactionSetNameFailedToSaveFaction=Fraktion konnte nicht gespeichert werden.
 CommandFactionSetNameSuccess=Fraktion-Name auf {0} gesetzt.
+CommandFactionSetNameFactionAlreadyExists=Eine Fraktion mit diesem Namen existiert bereits.
 CommandFactionSetPrefixNotAPlayer=Du hast nicht die Erlaubnis, den Präfix deiner Fraktion zu setzen.
 CommandFactionSetPrefixOperationCancelled=Operation abgebrochen.
 CommandFactionSetPrefixPrefixPrompt=Gib den neuen Präfix der Fraktion ein oder gib ''{0}'' ein, um abzubrechen.

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -515,6 +515,7 @@ CommandFactionSetNameNameTooLong=You cannot have a faction name longer than {0} 
 CommandFactionSetNameNoFactionPermission=Your role in this faction does not grant you permission to change its name.
 CommandFactionSetNameFailedToSaveFaction=Failed to save faction.
 CommandFactionSetNameSuccess=Faction name set to {0}.
+CommandFactionSetNameFactionAlreadyExists=A faction by that name already exists.
 CommandFactionSetPrefixNotAPlayer=You must be a player in order to set your faction''s prefix
 CommandFactionSetPrefixOperationCancelled=Operation cancelled.
 CommandFactionSetPrefixPrefixPrompt=Enter the new prefix of the faction, or type ''{0}'' to cancel.

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -515,6 +515,7 @@ CommandFactionSetNameNameTooLong=You cannot have a faction name longer than {0} 
 CommandFactionSetNameNoFactionPermission=Your role in this faction does not grant you permission to change its name.
 CommandFactionSetNameFailedToSaveFaction=Failed to save faction.
 CommandFactionSetNameSuccess=Faction name set to {0}.
+CommandFactionSetNameFactionAlreadyExists=A faction by that name already exists.
 CommandFactionSetPrefixNotAPlayer=You must be a player in order to set your faction''s prefix
 CommandFactionSetPrefixOperationCancelled=Operation cancelled.
 CommandFactionSetPrefixPrefixPrompt=Enter the new prefix of the faction, or type ''{0}'' to cancel.

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -515,6 +515,7 @@ CommandFactionSetNameNameTooLong=Le nom de votre faction ne peut pas dépasser {0
 CommandFactionSetNameNoFactionPermission=Votre rôle dans cette faction ne vous donne pas le droit de changer son nom.
 CommandFactionSetNameFailedToSaveFaction=Échec de l''enregistrement de la faction.
 CommandFactionSetNameSuccess=Le nom de la faction est réglé sur {0}.
+CommandFactionSetNameFactionAlreadyExists=Une faction de ce nom existe déjà.
 CommandFactionSetPrefixNotAPlayer=Vous devez être un joueur pour pouvoir définir le préfixe de votre faction.
 CommandFactionSetPrefixOperationCancelled=Opération annulée.
 CommandFactionSetPrefixPrefixPrompt=Entrez le nouveau préfixe de la faction, ou tapez ''{0}'' pour annuler.


### PR DESCRIPTION
We were checking for unique names when a faction was created, but not when it was renamed via the `set name `command. The changes in this PR add a unique name check to resolve this problem.

This was tested locally on a 1.18.2 spigot server.

closes #1706 