### PR TITLE
Denied access to `mf claim auto` command if either mf.claim.auto or mf.autoclaim perms are disabled.

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/claim/MfFactionClaimAutoCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/claim/MfFactionClaimAutoCommand.kt
@@ -14,7 +14,7 @@ import java.util.logging.Level.SEVERE
 
 class MfFactionClaimAutoCommand(private val plugin: MedievalFactions) : CommandExecutor, TabCompleter {
     override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
-        if (!sender.hasPermission("mf.claim.auto") && !sender.hasPermission("mf.autoclaim")) {
+        if (!sender.hasPermission("mf.claim.auto") || !sender.hasPermission("mf.autoclaim")) {
             sender.sendMessage("$RED${plugin.language["CommandFactionAutoclaimNoPermission"]}")
             return true
         }


### PR DESCRIPTION
This should resolve #1711 

Note: ~~this has not yet been tested~~ tested!