### PR TITLE
New Flag - `protectVillagerTrade`

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -56,6 +56,7 @@ import com.dansplugins.factionsystem.listener.EntityExplodeListener
 import com.dansplugins.factionsystem.listener.InventoryMoveItemListener
 import com.dansplugins.factionsystem.listener.LingeringPotionSplashListener
 import com.dansplugins.factionsystem.listener.PlayerDeathListener
+import com.dansplugins.factionsystem.listener.PlayerInteractEntityListener
 import com.dansplugins.factionsystem.listener.PlayerInteractListener
 import com.dansplugins.factionsystem.listener.PlayerJoinListener
 import com.dansplugins.factionsystem.listener.PlayerMoveListener
@@ -273,7 +274,8 @@ class MedievalFactions : JavaPlugin() {
             PlayerMoveListener(this),
             PlayerQuitListener(this),
             PlayerTeleportListener(this),
-            PotionSplashListener(this)
+            PotionSplashListener(this),
+            PlayerInteractEntityListener(this)
         )
 
         getCommand("faction")?.setExecutor(MfFactionCommand(this))

--- a/src/main/kotlin/com/dansplugins/factionsystem/faction/flag/MfFlags.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/faction/flag/MfFlags.kt
@@ -59,6 +59,11 @@ class MfFlags(
             plugin,
             "liegeChainCanInteractWithLand",
             plugin.config.getBoolean("factions.defaults.flags.liegeChainCanInteractWithLand")
+        ),
+        MfFlag.boolean(
+            plugin,
+            "protectVillagerTrade",
+            plugin.config.getBoolean("factions.defaults.flags.protectVillagerTrade")
         )
     )
 ) : MutableList<MfFlag<out Any>> by flags {
@@ -73,6 +78,7 @@ class MfFlags(
     val acceptBonusPower = get<Boolean>("acceptBonusPower")!!
     val enableMobProtection = get<Boolean>("enableMobProtection")!!
     val liegeChainCanInteractWithLand = get<Boolean>("liegeChainCanInteractWithLand")!!
+    val protectVillagerTrade = get<Boolean>("protectVillagerTrade")!!
 
     fun defaults() = MfFlagValues(plugin, flags.associate { it.name to it.defaultValue })
 }

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractEntityListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractEntityListener.kt
@@ -1,0 +1,54 @@
+package com.dansplugins.factionsystem.listener
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.player.MfPlayer
+import dev.forkhandles.result4k.onFailure
+import org.bukkit.ChatColor
+import org.bukkit.entity.EntityType
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import java.util.logging.Level
+
+class PlayerInteractEntityListener(private val plugin: MedievalFactions) : Listener {
+
+    @EventHandler
+    fun onPlayerInteractEntity(event: PlayerInteractEntityEvent) {
+        val playerService = plugin.services.playerService
+        val mfPlayer = playerService.getPlayer(event.player)
+        if (mfPlayer == null) {
+            event.isCancelled = true
+            plugin.server.scheduler.runTaskAsynchronously(
+                plugin,
+                Runnable {
+                    playerService.save(MfPlayer(plugin, event.player)).onFailure {
+                        event.player.sendMessage("${ChatColor.RED}${plugin.language["PlayerInteractEntityFailedToSavePlayer"]}")
+                        plugin.logger.log(Level.SEVERE, "Failed to save player: ${it.reason.message}", it.reason.cause)
+                        return@Runnable
+                    }
+                }
+            )
+            return
+        }
+
+        val clickedEntity = event.rightClicked
+        val clickedEntityType = clickedEntity.type
+        if (clickedEntityType == EntityType.VILLAGER) {
+            val claimService = plugin.services.claimService
+            val claim = claimService.getClaim(clickedEntity.location.chunk) ?: return
+            val factionService = plugin.services.factionService
+            val claimFaction = factionService.getFaction(claim.factionId) ?: return
+
+            val protectVillagerFlagValue = claimFaction.flags[plugin.flags.protectVillagerTrade]
+            if (protectVillagerFlagValue && !claimService.isInteractionAllowed(mfPlayer.id, claim)) {
+                if (mfPlayer.isBypassEnabled && event.player.hasPermission("mf.bypass")) {
+                    event.player.sendMessage("${ChatColor.RED}${plugin.language["FactionTerritoryProtectionBypassed"]}")
+                } else {
+                    event.isCancelled = true
+                    event.player.sendMessage("${ChatColor.RED}${plugin.language["PlayerInteractEntityCannotTradeWithVillager", claimFaction.name]}")
+                    return
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -74,6 +74,7 @@ factions:
       color: random # Can be hex colours, e.g. '#ffffff', '#ffcc00', etc., or 'random' to choose a random colour
       allowFriendlyFire: false
       acceptBonusPower: true
+      protectVillagerTrade: true
 chat:
   enableDefaultChatFormatting: true
   faction:

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1066,3 +1066,5 @@ CommandFactionAddMemberUnknownNewPlayerFaction=Unbekanntes neues Mitglied
 CommandFactionAddMemberSuccess=Dieser Spieler ist jetzt Mitglied der angegebenen Fraktion.
 CommandFactionHelpAddMember=/faction addmember <player> <faction> - Fügt zwangsweise ein Mitglied zu einer Fraktion hinzu.
 CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Du kannst die Berechtigung deiner Rolle nicht ändern, um die Berechtigungen deiner eigenen Rolle zu ändern.
+PlayerInteractEntityFailedToSavePlayer=Der Spieler konnte nicht gespeichert werden.
+PlayerInteractEntityCannotTradeWithVillager=Du kannst nicht mit diesem Dorfbewohner handeln.

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1068,3 +1068,5 @@ CommandFactionInfoAlliesTitle=Allies:
 CommandFactionInfoEnemiesTitle=Enemies:
 BlockNotLocked=That block is not locked.
 CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=You cannot modify your role''s permission to modify your own role''s permissions.
+PlayerInteractEntityFailedToSavePlayer=Failed to save player.
+PlayerInteractEntityCannotTradeWithVillager=You cannot trade with this villager.

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1068,3 +1068,5 @@ CommandFactionInfoVassalsTitle=Vassals:
 CommandFactionInfoAlliesTitle=Allies:
 CommandFactionInfoEnemiesTitle=Enemies:
 CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=You cannot modify your role''s permission to modify your own role''s permissions.
+PlayerInteractEntityFailedToSavePlayer=Failed to save player.
+PlayerInteractEntityCannotTradeWithVillager=You cannot trade with this villager.

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1068,3 +1068,5 @@ CommandFactionAddMemberSuccess=Ce joueur est maintenant membre de la faction spé
 CommandFactionHelpAddMember=/faction addmember <joueur> <faction> - Ajoute de force un membre à une faction.
 BlockNotLocked=Ce bloc n'est pas verrouillé.
 CommandFactionRoleSetPermissionCannotModifyRolePermissionToModifyOwnRolePermission=Vous ne pouvez pas modifier les autorisations de votre r\u00e9le pour modifier les autorisations de votre propre r\u00e9le.
+PlayerInteractEntityFailedToSavePlayer=Impossible de sauvegarder le joueur.
+PlayerInteractEntityCannotTradeWithVillager=Vous ne pouvez pas commercer avec ce villageois.


### PR DESCRIPTION
## Description
The `protectVillagerTrade` faction flag has been added to the plugin, allowing factions to control access to their villagers.

closes #1541 

## Testing
This has been tested on a 1.19.4 minecraft server. The flag can be set and trading behavior is as expected.