### PR TITLE
Expanded Territory Title Notifications

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
@@ -92,9 +92,12 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
                             Runnable {
                                 players.forEach { player ->
                                     val title = "${ChatColor.of(faction.flags[plugin.flags.color])}${faction.name}"
+                                    val subtitle = "${ChatColor.of(faction.flags[plugin.flags.color])}${faction.description}"
                                     if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                                         player.resetTitle()
-                                        player.sendTitle(title, null, 10, 70, 20)
+                                        player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                            plugin.config.getInt("factions.titleTerritoryDuration"),
+                                            plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
                                     }
                                     if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                                         player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))
@@ -138,7 +141,9 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
                                 "${ChatColor.of(plugin.config.getString("wilderness.color"))}${plugin.language["Wilderness"]}"
                             if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                                 player.resetTitle()
-                                player.sendTitle(title, null, 10, 70, 20)
+                                player.sendTitle(title, null, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                    plugin.config.getInt("factions.titleTerritoryDuration"),
+                                    plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
                             }
                             if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                                 player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
@@ -128,9 +128,12 @@ class MfFactionSetNameCommand(private val plugin: MedievalFactions) : CommandExe
                 onlinePlayers.filter { (_, chunk) -> claimService.getClaim(chunk)?.factionId == updatedFaction.id }
                     .forEach { (player, _) ->
                         val title = "${ChatColor.of(updatedFaction.flags[plugin.flags.color])}${updatedFaction.name}"
+                        val subtitle = "${ChatColor.of(updatedFaction.flags[plugin.flags.color])}${updatedFaction.description}"
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             player.resetTitle()
-                            player.sendTitle(title, null, 10, 70, 20)
+                            player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                plugin.config.getInt("factions.titleTerritoryDuration"),
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerJoinListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerJoinListener.kt
@@ -27,9 +27,18 @@ class PlayerJoinListener(private val plugin: MedievalFactions) : Listener {
                         } else {
                             "${ChatColor.of(plugin.config.getString("wilderness.color"))}${plugin.language["Wilderness"]}"
                         }
+
+                        val subtitle = if (newChunkFaction != null) {
+                            "${ChatColor.of(newChunkFaction.flags[plugin.flags.color])}${newChunkFaction.description}"
+                        } else {
+                            "${ChatColor.of(plugin.config.getString("wilderness.color"))}${plugin.language["Wilderness"]}"
+                        }
+
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             event.player.resetTitle()
-                            event.player.sendTitle(title, null, 10, 70, 20)
+                            event.player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                plugin.config.getInt("factions.titleTerritoryDuration"),
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             event.player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
@@ -85,9 +85,17 @@ class PlayerMoveListener(private val plugin: MedievalFactions) : Listener {
                         } else {
                             "${ChatColor.of(plugin.config.getString("wilderness.color"))}${plugin.language["Wilderness"]}"
                         }
+
+                        val subtitle = if (newChunkFaction != null) {
+                            "${ChatColor.of(newChunkFaction.flags[plugin.flags.color])}${newChunkFaction.description}"
+                        } else {
+                            null
+                        }
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             event.player.resetTitle()
-                            event.player.sendTitle(title, null, 10, 70, 20)
+                            event.player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                plugin.config.getInt("factions.titleTerritoryDuration"),
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             event.player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -62,10 +62,9 @@ factions:
   contiguousClaims: false
   actionBarTerritoryIndicator: true
   titleTerritoryIndicator: true
-  # "Length" is measured in ticks (20 ticks = 1 second).
-  titleTerritoryFadeInLength: 10
-  titleTerritoryDuration: 30
-  titleTerritoryFadeOutLength: 20
+  titleTerritoryFadeInLength: 5  # "Length" is measured in ticks (20 ticks = 1 second).
+  titleTerritoryDuration: 20
+  titleTerritoryFadeOutLength: 5
   allowNeutrality: false
   factionlessFactionName: Factionless
   factionHomeTeleportDelay: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -62,6 +62,10 @@ factions:
   contiguousClaims: false
   actionBarTerritoryIndicator: true
   titleTerritoryIndicator: true
+  # "Length" is measured in ticks (20 ticks = 1 second).
+  titleTerritoryFadeInLength: 10
+  titleTerritoryDuration: 30
+  titleTerritoryFadeOutLength: 20
   allowNeutrality: false
   factionlessFactionName: Factionless
   factionHomeTeleportDelay: 5


### PR DESCRIPTION
This PR expands upon the plugins call to the player.sendTitle method for territory notifcations.

- Territory indicator now includes the factions description, displayed as a subtitle. This brings it to parity with many other factions plugins. By default, it is also configured to be much shorter, as the title can become distracting in combat scenarios.

- The length of the title's fadeIn, duration, and fadeOut can now be controlled with a config.yml option.

Note that this creates an issue as there is no explicit length limit to the factions description, which may cause certain factions descriptions to go offscreen when being displayed as a title. Perhaps this might be limited, or another string could be stored in a faction, such as a tagline?