### PR TITLE
Apply lint to recent contribution.

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
@@ -95,9 +95,13 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
                                     val subtitle = "${ChatColor.of(faction.flags[plugin.flags.color])}${faction.description}"
                                     if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                                         player.resetTitle()
-                                        player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                        player.sendTitle(
+                                            title,
+                                            subtitle,
+                                            plugin.config.getInt("factions.titleTerritoryFadeInLength"),
                                             plugin.config.getInt("factions.titleTerritoryDuration"),
-                                            plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
+                                            plugin.config.getInt("factions.titleTerritoryFadeOutLength")
+                                        )
                                     }
                                     if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                                         player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))
@@ -141,9 +145,13 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
                                 "${ChatColor.of(plugin.config.getString("wilderness.color"))}${plugin.language["Wilderness"]}"
                             if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                                 player.resetTitle()
-                                player.sendTitle(title, null, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                                player.sendTitle(
+                                    title,
+                                    null,
+                                    plugin.config.getInt("factions.titleTerritoryFadeInLength"),
                                     plugin.config.getInt("factions.titleTerritoryDuration"),
-                                    plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
+                                    plugin.config.getInt("factions.titleTerritoryFadeOutLength")
+                                )
                             }
                             if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                                 player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/set/name/MfFactionSetNameCommand.kt
@@ -131,9 +131,13 @@ class MfFactionSetNameCommand(private val plugin: MedievalFactions) : CommandExe
                         val subtitle = "${ChatColor.of(updatedFaction.flags[plugin.flags.color])}${updatedFaction.description}"
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             player.resetTitle()
-                            player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                            player.sendTitle(
+                                title,
+                                subtitle,
+                                plugin.config.getInt("factions.titleTerritoryFadeInLength"),
                                 plugin.config.getInt("factions.titleTerritoryDuration"),
-                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength")
+                            )
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerJoinListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerJoinListener.kt
@@ -36,9 +36,13 @@ class PlayerJoinListener(private val plugin: MedievalFactions) : Listener {
 
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             event.player.resetTitle()
-                            event.player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                            event.player.sendTitle(
+                                title,
+                                subtitle,
+                                plugin.config.getInt("factions.titleTerritoryFadeInLength"),
                                 plugin.config.getInt("factions.titleTerritoryDuration"),
-                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength")
+                            )
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             event.player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerMoveListener.kt
@@ -93,9 +93,13 @@ class PlayerMoveListener(private val plugin: MedievalFactions) : Listener {
                         }
                         if (plugin.config.getBoolean("factions.titleTerritoryIndicator")) {
                             event.player.resetTitle()
-                            event.player.sendTitle(title, subtitle, plugin.config.getInt("factions.titleTerritoryFadeInLength"),
+                            event.player.sendTitle(
+                                title,
+                                subtitle,
+                                plugin.config.getInt("factions.titleTerritoryFadeInLength"),
                                 plugin.config.getInt("factions.titleTerritoryDuration"),
-                                plugin.config.getInt("factions.titleTerritoryFadeOutLength"))
+                                plugin.config.getInt("factions.titleTerritoryFadeOutLength")
+                            )
                         }
                         if (plugin.config.getBoolean("factions.actionBarTerritoryIndicator")) {
                             event.player.spigot().sendMessage(ACTION_BAR, *TextComponent.fromLegacyText(title))


### PR DESCRIPTION
We had a recent contribution that wasn't linted. This resolves the formatting inconsistencies.