### PR TITLE
New Law Permissions

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -133,13 +133,19 @@ permissions:
   mf.join:
     description: Allows joining factions
     default: true
-  mf.addlaw:
+  mf.law.add:
     description: Allows adding laws
     default: true
-  mf.laws:
-    description: Allows listing the laws of your faction
+  mf.law.edit:
+    description: Allows editing laws
     default: true
-  mf.removelaw:
+  mf.law.list:
+    description: Allows listing laws
+    default: true
+  mf.law.move:
+    description: Allows moving laws
+    default: true
+  mf.law.remove:
     description: Allows removing laws
     default: true
   mf.makepeace:


### PR DESCRIPTION
## Changes
The following permissions have been added to the plugin.yml:
- mf.law.add
- mf.law.edit
- mf.law.list
- mf.law.move
- mf.law.remove

I have also removed the old  `mf.addlaw`, `mf.laws` and `mf.removelaw` permissions.

closes #1729 