### PR TITLE
Resolve MariaDB driver when loading

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -142,6 +142,7 @@ class MedievalFactions : JavaPlugin() {
         language = Language(this, config.getString("language") ?: "en-US")
 
         Class.forName("org.h2.Driver")
+        Class.forName("org.mariadb.jdbc.Driver")
         val hikariConfig = HikariConfig()
         hikariConfig.jdbcUrl = config.getString("database.url")
         val databaseUsername = config.getString("database.username")


### PR DESCRIPTION
To be tested by _M0nsters on Discord, who initially reported the issue.
This PR should force the MariaDB driver to load by resolving it, therefore running the static initializer block in its class which registers it.
This should be made obsolete by Java's service loader mechanism (we do use mergeServiceFiles() in the shadow plugin partially for this reason) but if people are still reporting it, there's no harm in having it there.
