### PR TITLE
Config Option - Only Render Territories Upon Startup

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -300,6 +300,10 @@ class MedievalFactions : JavaPlugin() {
             MedievalFactionsPlaceholderExpansion(this).register()
         }
 
+        if (config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
+            logger.info(language["DynmapOnlyRenderTerritoriesUponStartupEnabled"])
+        }
+
         if (dynmapService != null) {
             factionService.factions.forEach { faction ->
                 dynmapService.scheduleUpdateClaims(faction)

--- a/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/claim/MfClaimService.kt
@@ -116,7 +116,7 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
             }
         )
         val dynmapService = plugin.services.dynmapService
-        if (dynmapService != null) {
+        if (dynmapService != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
             plugin.server.scheduler.runTask(
                 plugin,
                 Runnable {
@@ -167,7 +167,7 @@ class MfClaimService(private val plugin: MedievalFactions, private val repositor
         if (dynmapService != null) {
             val factionService = plugin.services.factionService
             val faction = factionService.getFaction(claim.factionId)
-            if (faction != null) {
+            if (faction != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
                 plugin.server.scheduler.runTask(
                     plugin,
                     Runnable {

--- a/src/main/kotlin/com/dansplugins/factionsystem/faction/MfFactionService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/faction/MfFactionService.kt
@@ -123,7 +123,7 @@ class MfFactionService(private val plugin: MedievalFactions, private val reposit
         val result = repository.upsert(factionToSave)
         factionsById[result.id] = result
         val dynmapService = plugin.services.dynmapService
-        if (dynmapService != null) {
+        if (dynmapService != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
             plugin.server.scheduler.runTask(
                 plugin,
                 Runnable {

--- a/src/main/kotlin/com/dansplugins/factionsystem/player/MfPlayerService.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/player/MfPlayerService.kt
@@ -53,7 +53,7 @@ class MfPlayerService(private val plugin: MedievalFactions, private val playerRe
         if (dynmapService != null) {
             val factionService = plugin.services.factionService
             val faction = factionService.getFaction(result.id)
-            if (faction != null) {
+            if (faction != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
                 plugin.server.scheduler.runTask(
                     plugin,
                     Runnable {
@@ -74,7 +74,7 @@ class MfPlayerService(private val plugin: MedievalFactions, private val playerRe
             playerRepository.decreaseOfflinePlayerPower(onlinePlayerIds)
             playersById.putAll(playerRepository.getPlayers().associateBy(MfPlayer::id))
             val dynmapService = plugin.services.dynmapService
-            if (dynmapService != null) {
+            if (dynmapService != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
                 val factionService = plugin.services.factionService
                 factionService.factions.forEach { faction ->
                     plugin.server.scheduler.runTask(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -94,5 +94,6 @@ duels:
   notificationDistance: 64
 dynmap:
   enableDynmapIntegration: true
+  onlyRenderTerritoriesUponStartup: false
 dev:
   enableDevCommands: false

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1074,3 +1074,4 @@ CommandFactionJoinFactionFull=Die Fraktion, der du beitreten möchtest, ist voll.
 CommandFactionAddMemberTargetFactionFull=Die Fraktion, zu der du diesen Spieler hinzufügen möchtest, ist voll.
 PlayerInteractEntityFailedToSavePlayer=Der Spieler konnte nicht gespeichert werden.
 PlayerInteractEntityCannotTradeWithVillager=Du kannst nicht mit diesem Dorfbewohner handeln.
+DynmapOnlyRenderTerritoriesUponStartupEnabled=Die Konfigurationsoption ?dynmap.onlyRenderTerritoriesUponStartup? ist aktiviert. Gebiete werden nur beim Start gerendert.

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1076,3 +1076,4 @@ CommandFactionJoinFactionFull=The faction you are trying to join is full.
 CommandFactionAddMemberTargetFactionFull=The faction you are trying to add a member to is full.
 PlayerInteractEntityFailedToSavePlayer=Failed to save player.
 PlayerInteractEntityCannotTradeWithVillager=You cannot trade with this villager.
+DynmapOnlyRenderTerritoriesUponStartupEnabled=The `dynmap.onlyRenderTerritoriesUponStartup` config option is enabled. Territories will only be rendered upon startup.

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1076,3 +1076,4 @@ CommandFactionJoinFactionFull=The faction you are trying to join is full.
 CommandFactionAddMemberTargetFactionFull=The faction you are trying to add a member to is full.
 PlayerInteractEntityFailedToSavePlayer=Failed to save player.
 PlayerInteractEntityCannotTradeWithVillager=You cannot trade with this villager.
+DynmapOnlyRenderTerritoriesUponStartupEnabled=The `dynmap.onlyRenderTerritoriesUponStartup` config option is enabled. Territories will only be rendered upon startup.

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1076,3 +1076,4 @@ CommandFactionJoinFactionFull=La faction est pleine.
 CommandFactionAddMemberTargetFactionFull=La faction est pleine.
 PlayerInteractEntityFailedToSavePlayer=Impossible de sauvegarder le joueur.
 PlayerInteractEntityCannotTradeWithVillager=Vous ne pouvez pas commercer avec ce villageois.
+DynmapOnlyRenderTerritoriesUponStartupEnabled=L'option de configuration `dynmap.onlyRenderTerritoriesUponStartup` est activée. Les territoires ne seront rendus qu'au démarrage.


### PR DESCRIPTION
## Problem
Rendering territories is causing a lot of lag for some servers.

## Solution
This PR introduces a config option to prevent the rendering of territories after the initial startup of the server. This limits the lag spike to one instance per session.

## Testing
This was used by a server owner in the community and their TPS improved from 15 to 18. This seems to ease the lag a bit.

## Related Issues
closes #1767 