### PR TITLE
Test Server Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu
+
+# Install dependencies
+RUN apt-get update
+RUN apt-get install -y git \
+    openjdk-17-jdk \
+    openjdk-17-jre \
+    wget \
+    locales
+
+# Create server directory
+WORKDIR /testmcserver
+
+# Build server
+RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+RUN git config --global --unset core.autocrlf || :
+RUN java -jar BuildTools.jar --rev 1.20.4
+RUN echo "eula=true" > eula.txt
+RUN mkdir plugins
+
+# set locale to support us, de, fr, & br
+RUN locale-gen en_US.UTF-8 de_DE.UTF-8 fr_FR.UTF-8 pt_BR.UTF-8 && \
+    update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
+    dpkg-reconfigure --frontend=noninteractive locales
+
+# Build plugin
+COPY . .
+RUN ./gradlew build
+RUN cp build/libs/*-all.jar plugins
+
+# Run server
+EXPOSE 25565
+ENTRYPOINT java -jar spigot-1.20.4.jar

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,7 @@
+services:
+  testmcserver:
+    build: .
+    image: mf-test-mc-server
+    container_name: mf-test-mc-server
+    ports:
+      - "25565:25565"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -75,11 +75,11 @@ commands:
     usage: /<command> [help|ally|breakalliance|declarewar|makepeace|create|invite|join|law|role|list|claim|unclaim|checkclaim|unclaimall|power|who|invoke|leave|vassalize|swearfealty|declareindependence|grantindependence|kick|map|sethome|home|flag|bypass|chat|set|bonuspower|relationship]
   lock:
     description: Enables or disables lock mode. To cancel lock mode, use /lock cancel.
-    aliases: [verschließen, verschliessen, verrouiller]
+    aliases: [verschlieBen, verschliessen, verrouiller]
     usage: /<command> (cancel)
   unlock:
     description: Enables or disables unlock mode. To cancel unlock mode, use /unlock cancel.
-    aliases: [aufschließen, aufschliessen, déverrouiller, deverrouiller]
+    aliases: [aufschlieBen, aufschliessen, deverrouiller, deverrouiller]
     usage: /<command> (cancel)
   accessors:
     description: |


### PR DESCRIPTION
## Docker
A Dockerfile has been added for a test server image. This can be spun up using the compose.yml file with `docker-compose up`

## Aliases in plugin.yml
Some aliases in the plugin.yml were modified to not use special characters, as this can result in the plugin being unusable on some servers due to the plugin.yml being unable to be parsed.