### PR TITLE
Fixed disabling neutrality preventing the plugin from enabling

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -183,6 +183,11 @@ class MedievalFactions : JavaPlugin() {
 
         val gson = Gson()
         val playerRepository: MfPlayerRepository = JooqMfPlayerRepository(this, dsl)
+        val dynmapService = if (server.pluginManager.getPlugin("dynmap") != null && config.getBoolean("dynmap.enableDynmapIntegration")) {
+            MfDynmapService(this)
+        } else {
+            null
+        }
         val factionRepository: MfFactionRepository = JooqMfFactionRepository(this, dsl, gson)
         val lawRepository: MfLawRepository = JooqMfLawRepository(dsl)
         val factionRelationshipRepository: MfFactionRelationshipRepository = JooqMfFactionRelationshipRepository(dsl)
@@ -208,11 +213,6 @@ class MedievalFactions : JavaPlugin() {
         val duelService = MfDuelService(this, duelRepository, duelInviteRepository)
         val potionService = MfPotionService(this)
         val teleportService = MfTeleportService(this)
-        val dynmapService = if (server.pluginManager.getPlugin("dynmap") != null && config.getBoolean("dynmap.enableDynmapIntegration")) {
-            MfDynmapService(this)
-        } else {
-            null
-        }
 
         services = Services(
             playerService,


### PR DESCRIPTION
## Problem
Creating a faction with neutrality enabled then toggling off neutrality in the config causes Medieval Factions to be unable to start.

## Solution
The DynmapService is now initialized before the FactionService.

## Relevant Issue
Closes #1765 