### PR TITLE
Dockerfile w/ Dynmap

### DIFF
--- a/Dockerfile.dynmap
+++ b/Dockerfile.dynmap
@@ -5,9 +5,16 @@ RUN apt-get update
 RUN apt-get install -y git \
     openjdk-17-jdk \
     openjdk-17-jre \
-    wget
+    wget \
+    git
 
 # Create server directory
+WORKDIR /testmcserver
+
+# Clone & build dynmap (placed here to take advantage of docker caching)
+RUN git clone https://github.com/webbukkit/dynmap
+WORKDIR /testmcserver/dynmap
+RUN /testmcserver/dynmap/gradlew :spigot:build
 WORKDIR /testmcserver
 
 # Build server
@@ -26,7 +33,9 @@ WORKDIR /testmcserver
 # Install plugin
 RUN cp /testmcserver/MedievalFactions/build/libs/*-all.jar /testmcserver/plugins
 
+# Install dynmap
+RUN cp /testmcserver/dynmap/target/Dynmap-*.jar /testmcserver/plugins
+
 # Run server
 EXPOSE 25565
-EXPOSE 8123
 ENTRYPOINT java -jar spigot-1.20.4.jar

--- a/compose-dynmap.yml
+++ b/compose-dynmap.yml
@@ -1,0 +1,10 @@
+services:
+  testmcserver:
+    build:
+      context: .
+      dockerfile: Dockerfile.dynmap
+    image: mf-test-mc-server-with-dynmap
+    container_name: mf-test-mc-server-with-dynmap
+    ports:
+      - "25565:25565"
+      - "8123:8123"


### PR DESCRIPTION
## Changes
A dockerfile including a dynmap installation has been added for testing purposes. This is intended to make testing the plugin with dynmap easier.

### Why build from source?
I would have downloaded the JAR, but it cannot be retrieved with 'wget' and the developers prohibit redistribution.

## Relevant Issue
closes #1782