### PR TITLE
Fixed power insufficiency check

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/claim/MfFactionClaimCircleCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/claim/MfFactionClaimCircleCommand.kt
@@ -92,7 +92,7 @@ class MfFactionClaimCircleCommand(private val plugin: MedievalFactions) : Comman
                                         val relationships = relationshipService.getRelationships(faction.id, claimFactionId)
                                         val reverseRelationships = relationshipService.getRelationships(claimFactionId, faction.id)
                                         return@filter (relationships + reverseRelationships).any { it.type == MfFactionRelationshipType.AT_WAR } &&
-                                            claimFaction.power < claimService.getClaims(claimFactionId).size - claims.size
+                                            claimFaction.power <= claimService.getClaims(claimFactionId).size - claims.size
                                     }
                                     .flatMap { it.value.map { (chunk, _) -> chunk } }
                                 val claimableChunks = unclaimedChunks + contestedChunks


### PR DESCRIPTION
## Problem
When a faction has 0 power and 1 claim, they cannot be conquered.

## Solution
The power insufficiency check has been modified to use 'less than or equals' instead of 'less than'.

## Testing
This was tested locally using the project's Dockerfile to spin up a container.

## Relevant Issue
Closes #1730 