### PR TITLE
Update Test Container to Minecraft 1.21.4 and Verify Plugin Compatibility

### DIFF
--- a/.testcontainer/post-create.sh
+++ b/.testcontainer/post-create.sh
@@ -1,8 +1,15 @@
 echo "Running 'post-create.sh' script..."
-if [ -z "$(ls -A /testmcserver)" ]; then
+if [ -z "$(ls -A /testmcserver)" ] || [ "$OVERWRITE_EXISTING_SERVER" = "true" ]; then
     echo "Setting up server..."
+
+    # if OVERWRITE_EXISTING_SERVER is true, delete the server directory
+    if [ "$OVERWRITE_EXISTING_SERVER" = "true" ]; then
+        echo "OVERWRITE_EXISTING_SERVER is set to 'true'. Deleting contents of /testmcserver..."
+        rm -rf /testmcserver/*
+    fi
+
     # Copy server JAR
-    cp /testmcserver-build/spigot-1.20.4.jar /testmcserver/spigot-1.20.4.jar
+cp /testmcserver-build/spigot-"${MINECRAFT_VERSION}".jar /testmcserver/spigot-"${MINECRAFT_VERSION}".jar
 
     # Create plugins directory
     mkdir /testmcserver/plugins
@@ -21,7 +28,7 @@ if [ -z "$(ls -A /testmcserver)" ]; then
     # Accept EULA
     cd /testmcserver && echo "eula=true" > eula.txt
 else
-    echo "Server is already set up."
+  echo "Server is already set up. To overwrite the existing server, set the 'OVERWRITE_EXISTING_SERVER' environment variable to 'true'."
 fi
 
 # Always delete lang directory to get the latest translations
@@ -51,4 +58,4 @@ else
 fi
 
 echo "Starting server..."
-java -jar /testmcserver/spigot-1.20.4.jar
+java -jar /testmcserver/spigot-"${MINECRAFT_VERSION}".jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM ubuntu
 
 # Install dependencies
-RUN apt-get update
-RUN apt-get install -y git \
-    openjdk-17-jdk \
-    openjdk-17-jre \
-    wget
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y wget git openjdk-21-jdk openjdk-21-jre
 
 # Build server
 WORKDIR /testmcserver-build
 RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 RUN git config --global --unset core.autocrlf || :
-RUN java -jar BuildTools.jar --rev 1.20.4
+RUN java -jar BuildTools.jar --rev 1.21.4
 
 # Copy plugin jar
 COPY ./build/libs /testmcserver-build/MedievalFactions/build/libs

--- a/compose.yml
+++ b/compose.yml
@@ -9,4 +9,6 @@ services:
     volumes:
       - ./testmcserver:/testmcserver
     environment:
+      - MINECRAFT_VERSION=${MINECRAFT_VERSION}
       - DYNMAP_ENABLED=${DYNMAP_ENABLED}
+      - OVERWRITE_EXISTING_SERVER=${OVERWRITE_EXISTING_SERVER}

--- a/sample.env
+++ b/sample.env
@@ -1,2 +1,4 @@
 # Whether test server should have dynmap installed
+MINECRAFT_VERSION=1.21.4
 DYNMAP_ENABLED=true
+OVERWRITE_EXISTING_SERVER=false


### PR DESCRIPTION
## Problem  
The plugin has not yet been tested with the latest Minecraft version (1.21.4).  

## Solution  
The test container has been updated to use Minecraft 1.21.4.  

### Additional Changes  
- The latest version of Dynmap has been added to the tracked files.  
- A new environment variable, `OVERWRITE_EXISTING_SERVER` has been added to the sample.env.

## Testing  
- The server successfully recognized Medieval Factions on startup.  
- A test faction with one claim persisted after a server restart.