### PR TITLE
Enable Bluemap in Test Server

### DIFF
--- a/.testcontainer/post-create.sh
+++ b/.testcontainer/post-create.sh
@@ -1,8 +1,15 @@
 echo "Running 'post-create.sh' script..."
-if [ -z "$(ls -A /testmcserver)" ]; then
+if [ -z "$(ls -A /testmcserver)" ] || [ "$OVERWRITE_EXISTING_SERVER" = "true" ]; then
     echo "Setting up server..."
+
+    # if OVERWRITE_EXISTING_SERVER is true, delete the server directory
+    if [ "$OVERWRITE_EXISTING_SERVER" = "true" ]; then
+        echo "OVERWRITE_EXISTING_SERVER is set to 'true'. Deleting contents of /testmcserver..."
+        rm -rf /testmcserver/*
+    fi
+
     # Copy server JAR
-    cp /testmcserver-build/spigot-1.20.4.jar /testmcserver/spigot-1.20.4.jar
+cp /testmcserver-build/spigot-"${MINECRAFT_VERSION}".jar /testmcserver/spigot-"${MINECRAFT_VERSION}".jar
 
     # Create plugins directory
     mkdir /testmcserver/plugins
@@ -21,7 +28,7 @@ if [ -z "$(ls -A /testmcserver)" ]; then
     # Accept EULA
     cd /testmcserver && echo "eula=true" > eula.txt
 else
-    echo "Server is already set up."
+  echo "Server is already set up. To overwrite the existing server, set the 'OVERWRITE_EXISTING_SERVER' environment variable to 'true'."
 fi
 
 # Always delete lang directory to get the latest translations
@@ -51,4 +58,4 @@ else
 fi
 
 echo "Starting server..."
-java -jar /testmcserver/spigot-1.20.4.jar
+java -jar /testmcserver/spigot-"${MINECRAFT_VERSION}".jar

--- a/.testcontainer/post-create.sh
+++ b/.testcontainer/post-create.sh
@@ -57,5 +57,18 @@ else
     rm -f /testmcserver/plugins/Dynmap-*.jar
 fi
 
+# Copy or delete Bluemap JAR based on environment variable
+if [ "$BLUEMAP_ENABLED" = "true" ]; then
+      echo "Bluemap enabled. Copying Bluemap plugin from /resources/jars..."
+      cp /resources/jars/bluemap-*.jar /testmcserver/plugins
+
+      # update /testmcserver/plugins/bluemap/core.conf to have accept-download: true
+      echo "Updating /testmcserver/plugins/bluemap/core.conf to have accept-download: true..."
+      sed -i 's/accept-download: false/accept-download: true/g' /testmcserver/plugins/bluemap/core.conf
+else
+    echo "Bluemap disabled. Deleting Bluemap plugin if it exists..."
+    rm -f /testmcserver/plugins/bluemap-*.jar
+fi
+
 echo "Starting server..."
 java -jar /testmcserver/spigot-"${MINECRAFT_VERSION}".jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM ubuntu
 
 # Install dependencies
-RUN apt-get update
-RUN apt-get install -y git \
-    openjdk-17-jdk \
-    openjdk-17-jre \
-    wget
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y wget git openjdk-21-jdk openjdk-21-jre
 
 # Build server
 WORKDIR /testmcserver-build
 RUN wget -O BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
 RUN git config --global --unset core.autocrlf || :
-RUN java -jar BuildTools.jar --rev 1.20.4
+RUN java -jar BuildTools.jar --rev 1.21.4
 
 # Copy plugin jar
 COPY ./build/libs /testmcserver-build/MedievalFactions/build/libs

--- a/compose.yml
+++ b/compose.yml
@@ -9,4 +9,6 @@ services:
     volumes:
       - ./testmcserver:/testmcserver
     environment:
+      - MINECRAFT_VERSION=${MINECRAFT_VERSION}
       - DYNMAP_ENABLED=${DYNMAP_ENABLED}
+      - OVERWRITE_EXISTING_SERVER=${OVERWRITE_EXISTING_SERVER}

--- a/compose.yml
+++ b/compose.yml
@@ -6,9 +6,11 @@ services:
     ports:
       - "25565:25565"
       - "8123:8123"
+      - "8100:8100"
     volumes:
       - ./testmcserver:/testmcserver
     environment:
       - MINECRAFT_VERSION=${MINECRAFT_VERSION}
-      - DYNMAP_ENABLED=${DYNMAP_ENABLED}
       - OVERWRITE_EXISTING_SERVER=${OVERWRITE_EXISTING_SERVER}
+      - DYNMAP_ENABLED=${DYNMAP_ENABLED}
+      - BLUEMAP_ENABLED=${BLUEMAP_ENABLED}

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,11 @@
-# Whether test server should have dynmap installed
+# Version of minecraft expected to be installed
 MINECRAFT_VERSION=1.21.4
-DYNMAP_ENABLED=true
+
+# Whether to overwrite existing server
 OVERWRITE_EXISTING_SERVER=false
+
+# Whether test server should have dynmap installed
+DYNMAP_ENABLED=false
+
+# Whether test server should have bluemap installed
+BLUEMAP_ENABLED=true

--- a/sample.env
+++ b/sample.env
@@ -1,2 +1,4 @@
 # Whether test server should have dynmap installed
+MINECRAFT_VERSION=1.21.4
 DYNMAP_ENABLED=true
+OVERWRITE_EXISTING_SERVER=false

--- a/sample.env
+++ b/sample.env
@@ -5,7 +5,7 @@ MINECRAFT_VERSION=1.21.4
 OVERWRITE_EXISTING_SERVER=false
 
 # Whether test server should have dynmap installed
-DYNMAP_ENABLED=false
+DYNMAP_ENABLED=true
 
 # Whether test server should have bluemap installed
-BLUEMAP_ENABLED=true
+BLUEMAP_ENABLED=false


### PR DESCRIPTION
## Problem  
The test server must be able to run Bluemap before Bluemap support can be implemented.  

## Solution  
A new environment variable has been added to `sample.env` to enable the Bluemap plugin. When set to `true`, Bluemap will be installed in the test container.  

## Testing  
After starting the test container, Bluemap was verified to be accessible at `localhost:8100`.