### PR TITLE
Updated dynmap upon faction disbandment

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/disband/MfFactionDisbandCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/disband/MfFactionDisbandCommand.kt
@@ -78,6 +78,16 @@ class MfFactionDisbandCommand(private val plugin: MedievalFactions) : CommandExe
                     return@Runnable
                 }
                 sender.sendMessage("$GREEN${plugin.language["CommandFactionDisbandSuccess"]}")
+
+                val mapService = plugin.services.mapService
+                if (mapService != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
+                    plugin.server.scheduler.runTask(
+                        plugin,
+                        Runnable {
+                            mapService.scheduleUpdateClaims(faction)
+                        }
+                    )
+                }
             }
         )
         return true

--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/unclaimall/MfFactionUnclaimAllCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/unclaimall/MfFactionUnclaimAllCommand.kt
@@ -50,6 +50,16 @@ class MfFactionUnclaimAllCommand(private val plugin: MedievalFactions) : Command
                     return@Runnable
                 }
                 sender.sendMessage("$GREEN${plugin.language["CommandFactionUnclaimAllSuccess"]}")
+
+                val mapService = plugin.services.mapService
+                if (mapService != null && !plugin.config.getBoolean("dynmap.onlyRenderTerritoriesUponStartup")) {
+                    plugin.server.scheduler.runTask(
+                        plugin,
+                        Runnable {
+                            mapService.scheduleUpdateClaims(faction)
+                        }
+                    )
+                }
             }
         )
         return true


### PR DESCRIPTION
## Problem
Claims on the dynmap are not updated upon faction disbandment.

## Solution
A call to MapService.scheduleUpdateClaims has been added to the disband command.

### Additional changes
- A call to MapService.scheduleUpdateClaims has been added to the unclaimall command.

## Testing
Tested locally using test server