### PR TITLE
Prevent Anvil Duplication Exploit via Falling Blocks in Gates  

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
@@ -21,7 +21,6 @@ import com.dansplugins.factionsystem.player.MfPlayerId
 import dev.forkhandles.result4k.onFailure
 import org.bukkit.ChatColor.GREEN
 import org.bukkit.ChatColor.RED
-import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace.DOWN
 import org.bukkit.block.BlockFace.UP
@@ -361,37 +360,12 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         )
     }
 
-    private val restrictedBlocksForGates = setOf(
-        Material.SAND,
-        Material.RED_SAND,
-        Material.GRAVEL,
-        Material.ANVIL,
-        Material.WHITE_CONCRETE_POWDER,
-        Material.ORANGE_CONCRETE_POWDER,
-        Material.MAGENTA_CONCRETE_POWDER,
-        Material.LIGHT_BLUE_CONCRETE_POWDER,
-        Material.YELLOW_CONCRETE_POWDER,
-        Material.LIME_CONCRETE_POWDER,
-        Material.PINK_CONCRETE_POWDER,
-        Material.GRAY_CONCRETE_POWDER,
-        Material.LIGHT_GRAY_CONCRETE_POWDER,
-        Material.CYAN_CONCRETE_POWDER,
-        Material.PURPLE_CONCRETE_POWDER,
-        Material.BLUE_CONCRETE_POWDER,
-        Material.BROWN_CONCRETE_POWDER,
-        Material.GREEN_CONCRETE_POWDER,
-        Material.RED_CONCRETE_POWDER,
-        Material.BLACK_CONCRETE_POWDER,
-        Material.DRAGON_EGG,
-        Material.SCAFFOLDING
-    )
-
     private fun selectGatePosition1(player: Player, block: Block) {
         plugin.server.scheduler.runTaskAsynchronously(
             plugin,
             Runnable {
-                if (block.type in restrictedBlocksForGates) {
-                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}") // TODO: add language key
+                if (block.type in plugin.services.gateService.fallingBlockMaterials) {
+                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}")
                     return@Runnable
                 }
                 val playerService = plugin.services.playerService
@@ -426,8 +400,8 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         plugin.server.scheduler.runTaskAsynchronously(
             plugin,
             Runnable {
-                if (block.type in restrictedBlocksForGates) {
-                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}") // TODO: add language key
+                if (block.type in plugin.services.gateService.fallingBlockMaterials) {
+                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}")
                     return@Runnable
                 }
                 val playerService = plugin.services.playerService
@@ -462,8 +436,8 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         plugin.server.scheduler.runTaskAsynchronously(
             plugin,
             Runnable {
-                if (block.type in restrictedBlocksForGates) {
-                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}") // TODO: add language key
+                if (block.type in plugin.services.gateService.fallingBlockMaterials) {
+                    player.sendMessage("$RED${plugin.language["GateCreateRestrictedBlock"]}")
                     return@Runnable
                 }
                 val playerService = plugin.services.playerService
@@ -525,11 +499,12 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
                     return@syncValidations
                 }
 
-                // Validate restricted blocks within the area
                 val blocks = area.blocks
-                val restrictedBlock = blocks.firstOrNull { it.toBukkitBlock()?.type in restrictedBlocksForGates }
+
+                // Validate restricted blocks within the area
+                val restrictedBlock = blocks.firstOrNull { it.toBukkitBlock()?.type in plugin.services.gateService.fallingBlockMaterials }
                 if (restrictedBlock != null) {
-                    player.sendMessage("$RED${plugin.language["GateCreateAreaRestrictedBlock"]}") // TODO: add language key
+                    player.sendMessage("$RED${plugin.language["GateCreateAreaRestrictedBlock"]}")
                     restartGateCreation(player, ctx)
                     return@syncValidations
                 }

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1132,3 +1132,5 @@ CommandFactionHelpApply=/faction apply [Fraktionsname] - Bewirb dich, um einer F
 CommandFactionHelpApproveApp=/faction approveapp <Spieler> - Genehmige die Bewerbung eines Spielers für deine Fraktion.  
 CommandFactionHelpDenyApp=/faction denyapp <Spieler> - Lehne die Bewerbung eines Spielers für deine Fraktion ab.
 CommandFactionAddMemberFailedToCancelApplications=Fehler beim Stornieren von Bewerbungen.
+GateCreateRestrictedBlock=Ein Tor kann nicht mit diesem Block erstellt werden.
+GateCreateAreaRestrictedBlock=Das Tor, das Sie zu erstellen versuchen, enthält einen eingeschränkten Block.

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1131,3 +1131,5 @@ CommandFactionHelpApply=/faction apply [faction name] - Apply to join a faction.
 CommandFactionHelpApproveApp=/faction approveapp <player> - Approve a player's application to join your faction.
 CommandFactionHelpDenyApp=/faction denyapp <player> - Deny a player's application to join your faction.
 CommandFactionAddMemberFailedToCancelApplications=Failed to cancel applications.
+GateCreateRestrictedBlock=A gate cannot be created using that block.
+GateCreateAreaRestrictedBlock=The gate you are attempting to create contains a restricted block.

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1128,3 +1128,5 @@ CommandFactionHelpApply=/faction apply [faction name] - Apply to join a faction.
 CommandFactionHelpApproveApp=/faction approveapp <player> - Approve a player's application to join your faction.
 CommandFactionHelpDenyApp=/faction denyapp <player> - Deny a player's application to join your faction.
 CommandFactionAddMemberFailedToCancelApplications=Failed to cancel applications.
+GateCreateRestrictedBlock=A gate cannot be created using that block.
+GateCreateAreaRestrictedBlock=The gate you are attempting to create contains a restricted block.

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1134,3 +1134,5 @@ CommandFactionHelpApply=/faction apply [nom de la faction] - Postuler pour rejoi
 CommandFactionHelpApproveApp=/faction approveapp <joueur> - Approuver la candidature d'un joueur pour rejoindre votre faction.
 CommandFactionHelpDenyApp=/faction denyapp <joueur> - Refuser la candidature d'un joueur pour rejoindre votre faction.
 CommandFactionAddMemberFailedToCancelApplications=Échec de l'annulation des candidatures.
+GateCreateRestrictedBlock=Un portail ne peut pas être créé avec ce bloc.
+GateCreateAreaRestrictedBlock=Le portail que vous essayez de créer contient un bloc restreint.

--- a/src/main/resources/lang/lang_pt_BR.properties
+++ b/src/main/resources/lang/lang_pt_BR.properties
@@ -1130,3 +1130,5 @@ CommandFactionHelpApply=/faction apply [nome da facção] - Candidatar-se para ent
 CommandFactionHelpApproveApp=/faction approveapp <jogador> - Aprovar a candidatura de um jogador para entrar na sua facção.
 CommandFactionHelpDenyApp=/faction denyapp <jogador> - Recusar a candidatura de um jogador para entrar na sua facção.
 CommandFactionAddMemberFailedToCancelApplications=Falha ao cancelar candidaturas.
+GateCreateRestrictedBlock=Um portão não pode ser criado usando esse bloco.
+GateCreateAreaRestrictedBlock=O portão que você está tentando criar contém um bloco restrito.


### PR DESCRIPTION
## Problem  
Players were able to exploit falling blocks, particularly anvils, when creating gates to duplicate items. This unintended behavior could lead to economy imbalances and game-breaking mechanics.  

## Solution  
- Updated `PlayerInteractListener` to prevent the use of falling blocks (e.g., anvils, sand, gravel) when creating gates.  
- Implemented a cleanup mechanism to delete any existing gates using falling blocks upon server startup, ensuring previously created invalid gates are removed.  

## Testing  
- [x] Verified that gate creation is prevented when attempting to use falling blocks.  
- [x] Confirmed that valid gates can still be created with stable blocks.  
- [x] Ensured that on server startup, any gates containing falling blocks are identified and removed.  