### PR TITLE
Prevent Gate Blocks from Being Destroyed by Fire

### DIFF
--- a/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/MedievalFactions.kt
@@ -44,6 +44,7 @@ import com.dansplugins.factionsystem.listener.AreaEffectCloudApplyListener
 import com.dansplugins.factionsystem.listener.AsyncPlayerChatListener
 import com.dansplugins.factionsystem.listener.AsyncPlayerPreLoginListener
 import com.dansplugins.factionsystem.listener.BlockBreakListener
+import com.dansplugins.factionsystem.listener.BlockBurnListener
 import com.dansplugins.factionsystem.listener.BlockExplodeListener
 import com.dansplugins.factionsystem.listener.BlockPistonExtendListener
 import com.dansplugins.factionsystem.listener.BlockPistonRetractListener
@@ -315,6 +316,7 @@ class MedievalFactions : JavaPlugin() {
             AsyncPlayerChatListener(this),
             AsyncPlayerPreLoginListener(this),
             BlockBreakListener(this),
+            BlockBurnListener(this),
             BlockExplodeListener(this),
             BlockPistonExtendListener(this),
             BlockPistonRetractListener(this),

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListener.kt
@@ -9,7 +9,7 @@ import org.bukkit.event.block.BlockBurnEvent
 class BlockBurnListener(private val plugin: MedievalFactions) : Listener {
 
     @EventHandler
-    fun onBlockExplode(event: BlockBurnEvent) {
+    fun onBlockBurn(event: BlockBurnEvent) {
         val gateService = plugin.services.gateService
         val block = event.block
 

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListener.kt
@@ -1,0 +1,23 @@
+package com.dansplugins.factionsystem.listener
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.area.MfBlockPosition
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBurnEvent
+
+class BlockBurnListener(private val plugin: MedievalFactions) : Listener {
+
+    @EventHandler
+    fun onBlockExplode(event: BlockBurnEvent) {
+        val gateService = plugin.services.gateService
+        val block = event.block
+
+        val blockPosition = MfBlockPosition.fromBukkitBlock(block)
+
+        // if block is part of a gate, cancel the event
+        if (gateService.getGatesAt(blockPosition).isNotEmpty() || gateService.getGatesByTrigger(blockPosition).isNotEmpty()) {
+            event.isCancelled = true
+        }
+    }
+}

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/BlockBurnListenerTest.kt
@@ -1,0 +1,77 @@
+package com.dansplugins.factionsystem.listener
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.area.MfBlockPosition
+import com.dansplugins.factionsystem.gate.MfGate
+import com.dansplugins.factionsystem.gate.MfGateService
+import org.bukkit.World
+import org.bukkit.block.Block
+import org.bukkit.event.block.BlockBurnEvent
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class BlockBurnListenerTest {
+
+    private lateinit var medievalFactions: MedievalFactions
+    private lateinit var gateService: MfGateService
+    private lateinit var blockBurnListener: BlockBurnListener
+
+    @BeforeEach
+    fun setUp() {
+        medievalFactions = mock(MedievalFactions::class.java)
+        gateService = mock(MfGateService::class.java)
+
+        // Mocking services object in MedievalFactions
+        val services = mock(com.dansplugins.factionsystem.service.Services::class.java)
+        `when`(medievalFactions.services).thenReturn(services)
+        `when`(services.gateService).thenReturn(gateService)
+
+        blockBurnListener = BlockBurnListener(medievalFactions)
+    }
+
+    @Test
+    fun onBlockBurn_ShouldCancelEvent_WhenBlockIsPartOfGate() {
+        val block = mock(Block::class.java)
+        val world = mock(World::class.java) // Mock the World
+        val worldUid = mock(java.util.UUID::class.java)
+        `when`(block.world).thenReturn(world) // Ensure getWorld() returns a non-null mock
+        `when`(block.x).thenReturn(0)
+        `when`(block.y).thenReturn(0)
+        `when`(block.z).thenReturn(0)
+        `when`(world.uid).thenReturn(worldUid) // Ensure getUID() returns a non-null mock
+
+        val event = mock(BlockBurnEvent::class.java)
+        `when`(event.block).thenReturn(block)
+        val blockPosition = MfBlockPosition.fromBukkitBlock(block)
+        `when`(gateService.getGatesAt(blockPosition)).thenReturn(listOf(mock(MfGate::class.java)))
+
+        blockBurnListener.onBlockBurn(event)
+
+        verify(event, times(1)).isCancelled = true
+    }
+
+    @Test
+    fun onBlockBurn_ShouldNotCancelEvent_WhenBlockIsNotPartOfGate() {
+        val block = mock(Block::class.java)
+        val world = mock(World::class.java) // Mock the World
+        val worldUid = mock(java.util.UUID::class.java)
+        `when`(block.world).thenReturn(world) // Ensure getWorld() returns a non-null mock
+        `when`(block.x).thenReturn(0)
+        `when`(block.y).thenReturn(0)
+        `when`(block.z).thenReturn(0)
+        `when`(world.uid).thenReturn(worldUid) // Ensure getUID() returns a non-null mock
+
+        val event = mock(BlockBurnEvent::class.java)
+        `when`(event.block).thenReturn(block)
+        val blockPosition = MfBlockPosition.fromBukkitBlock(block)
+        `when`(gateService.getGatesAt(blockPosition)).thenReturn(emptyList())
+
+        blockBurnListener.onBlockBurn(event)
+
+        verify(event, times(0)).isCancelled = true
+    }
+}


### PR DESCRIPTION
## Problem  
Gate blocks can be destroyed by fire.  

## Solution  
A new event listener has been added to prevent gate blocks from burning.  

## Verification  
Tested on the server to confirm that gate blocks no longer break when set on fire.

![image](https://github.com/user-attachments/assets/0aef9313-56bd-4ef4-8b48-9c7e7c9cff80)
