### PR TITLE
Fixed plugin JARs getting deleted incorrectly in `post-create.sh`

### DIFF
--- a/.testcontainer/post-create.sh
+++ b/.testcontainer/post-create.sh
@@ -77,6 +77,8 @@ manage_plugin_dependencies() {
     if [ "${!enabled_var}" = "true" ]; then
         log "${plugin_name} enabled. Copying plugin JAR..."
         cp "$RESOURCES_DIR"/${plugin_name}-*.jar "$SERVER_DIR"/plugins
+    elif [ "${!enabled_var}" = "false" ]; then
+        log "${plugin_name} disabled. Removing plugin JAR if it exists..."
         rm -f "$SERVER_DIR"/plugins/${plugin_name}-*.jar
     fi
 }


### PR DESCRIPTION
## Problem
Recent updates to the `post-create.sh` script introduced a bug where plugin JARs were getting deleted after being copied.

## Solution
The logic in `post-create.sh` was updated to prevent this problem.

## Testing
Ensured that plugin JARs were present after spinning up test server.