### PR TITLE
docs: add CHANGELOG entry for 5.8.1 and realign 5.8.0 heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## 5.8.0 - 2026-04-25
+## [5.8.1] – 2026-04-25
+
+### Fixed
+- Holding a `wartimePlaceableBlocks` item (e.g. ladders or scaffolding) no longer bypasses interaction protection on enemy territory blocks such as chests and levers during wartime.
+
+## [5.8.0] – 2026-04-25
 
 ### Added
 - `factions.wartimePlaceableBlocks`: configurable list of block types that attackers can place in enemy territory during war.


### PR DESCRIPTION
## Summary
- **Adds the missing `[5.8.1]` CHANGELOG entry.** Version 5.8.1 was released and tagged (`v5.8.1`) but the changelog jumped straight from 5.8.0 to nothing — the release was undocumented. The entry records its single fix from PR #1969: holding a `wartimePlaceableBlocks` item (ladders, scaffolding) no longer bypasses interaction protection on enemy territory blocks (chests, levers) during wartime.
- **Realigns the `[5.8.0]` heading** to the bracketed, en-dash format (`## [x.y.z] – date`) used by every other entry from 5.1.4 through 5.7.2. The 5.8.0 heading had reverted to a plain `## 5.8.0 - date` (no brackets, ASCII hyphen), breaking the series; fixed here as a sibling-consistency change.

## Test plan
- [x] Documentation-only change — no code, tests, migrations, config, or DPC surface touched.
- [x] 5.8.1 entry verified against the actual release diff (commit `2b54effe` / PR #1969), not just the commit subject.
- [x] Heading separator bytes confirmed to match the existing series (brackets + U+2013 en-dash).
- [x] CI build expected to be unaffected (Markdown-only).

## Data-safety statement
No schema migrations; no DPC contract change; no config-default change. CHANGELOG.md only.

## Tracking
No tracking issue — doc-drift gap found during triage (a released version with no changelog entry).

---
### Cycle triage note (deferred backlog)
This cycle was scoped to the highest-value, zero-risk item surfaced at triage (the undocumented 5.8.1 release). The remaining open issues were deferred: most already have in-flight `copilot/*` draft PRs (e.g. #1958→#1959, #1952→#1954, #1943→#1944, #1947→#1948, #1914→#1915), and the rest are larger feature/bug work outside the scope of a documentation cycle. PR #1959 (DPC integration) was intentionally left untouched at the user's request.

_Drafted by Claude on behalf of Daniel Stephenson._