### PR TITLE
Show faction claim count in /f power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- `/faction power` now also reports a faction's claim count. When `factions.limitLand` is enabled it is shown as `claimed/capacity` (capacity equals the faction's current power); otherwise just the number of claimed chunks is shown.
 - `/faction declinevassalization [faction]` command (permission `mf.declinevassalization`, default `true`): lets a faction decline a pending vassalization request sent to it, with notifications to both factions.
 - DPC community API integration: opt-in sync of faction data to `https://dansplugins.com` via `POST /api/v1/factions`. Enabled with `/mf dpc optin` and configured under the `dpc-api.*` section of `config.yml`. Requires an API key from the DPC website.
 - `/mf dpc` subcommand (permission `mf.dpc`, default `op`) with `optin`, `optout`, `reminder on|off`, `shareip on|off`, `discord <link>|clear` actions.

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -395,7 +395,7 @@ See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 
 ### `/faction power` or `/f power`
 **Permission:** `mf.power` (default: true)  
-**Description:** Displays power statistics for yourself or your faction.  
+**Description:** Displays power statistics for yourself or your faction. When viewing a faction, also shows the number of chunks it has claimed; if `factions.limitLand` is enabled, this is shown as `claimed/capacity` where the capacity equals the faction's current power.  
 **Usage:** `/f power`
 
 ### `/power set [player] [amount]`

--- a/src/main/kotlin/com/dansplugins/factionsystem/command/faction/power/MfFactionPowerCommand.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/command/faction/power/MfFactionPowerCommand.kt
@@ -121,6 +121,28 @@ class MfFactionPowerCommand(private val plugin: MedievalFactions) : CommandExecu
                             ]
                             }"
                         )
+                        val claimService = plugin.services.claimService
+                        val claimCount = claimService.getClaims(faction.id).size
+                        if (plugin.config.getBoolean("factions.limitLand")) {
+                            sender.sendMessage(
+                                "$GRAY${
+                                plugin.language[
+                                    "CommandFactionPowerFactionClaims",
+                                    decimalFormat.format(claimCount.toLong()),
+                                    decimalFormat.format(floor(faction.power))
+                                ]
+                                }"
+                            )
+                        } else {
+                            sender.sendMessage(
+                                "$GRAY${
+                                plugin.language[
+                                    "CommandFactionPowerFactionClaimsUnlimited",
+                                    decimalFormat.format(claimCount.toLong())
+                                ]
+                                }"
+                            )
+                        }
                     }
                 } else {
                     sender.sendMessage("$RED${plugin.language["CommandFactionPowerNotAPlayer"]}")

--- a/src/main/resources/lang/lang_de_DE.properties
+++ b/src/main/resources/lang/lang_de_DE.properties
@@ -1197,3 +1197,5 @@ FactionVassalizationRequestDeclinedNotificationTitle=Vasallisierungsanfrage der 
 FactionVassalizationRequestDeclinedNotificationBody=Ihre Fraktion hat eine Vasallisierungsanfrage von {0} abgelehnt.
 FactionVassalizationRequestRejectedNotificationTitle=Vasallisierungsanfrage abgelehnt
 FactionVassalizationRequestRejectedNotificationBody={0} hat Ihre Vasallisierungsanfrage abgelehnt.
+CommandFactionPowerFactionClaims=Beanspruchte Gebiete: {0}/{1}
+CommandFactionPowerFactionClaimsUnlimited=Beanspruchte Gebiete: {0}

--- a/src/main/resources/lang/lang_en_GB.properties
+++ b/src/main/resources/lang/lang_en_GB.properties
@@ -1203,3 +1203,5 @@ CommandFactionDpcDiscordClearSuccess=DPC API Discord link has been cleared.
 CommandFactionDpcDiscordInvalidLink=Invalid Discord link. Must start with https://discord.gg/ or https://discord.com/.
 DpcLoginReminder=[Medieval Factions] Want to share your faction data with the DPC community? Get an API key at https://dansplugins.com, set dpc-api.key and dpc-api.server-id in config.yml, then run /mf dpc optin. Other options: /mf dpc shareip, /mf dpc discord, /mf dpc reminder off to hide this message.
 CommandFactionHelpDpc=/faction dpc - Manage DPC community API integration settings.
+CommandFactionPowerFactionClaims=Faction claims: {0}/{1}
+CommandFactionPowerFactionClaimsUnlimited=Faction claims: {0}

--- a/src/main/resources/lang/lang_en_US.properties
+++ b/src/main/resources/lang/lang_en_US.properties
@@ -1200,3 +1200,5 @@ CommandFactionDpcDiscordClearSuccess=DPC API Discord link has been cleared.
 CommandFactionDpcDiscordInvalidLink=Invalid Discord link. Must start with https://discord.gg/ or https://discord.com/.
 DpcLoginReminder=[Medieval Factions] Want to share your faction data with the DPC community? Get an API key at https://dansplugins.com, set dpc-api.key and dpc-api.server-id in config.yml, then run /mf dpc optin. Other options: /mf dpc shareip, /mf dpc discord, /mf dpc reminder off to hide this message.
 CommandFactionHelpDpc=/faction dpc - Manage DPC community API integration settings.
+CommandFactionPowerFactionClaims=Faction claims: {0}/{1}
+CommandFactionPowerFactionClaimsUnlimited=Faction claims: {0}

--- a/src/main/resources/lang/lang_fr_FR.properties
+++ b/src/main/resources/lang/lang_fr_FR.properties
@@ -1198,3 +1198,5 @@ FactionVassalizationRequestDeclinedNotificationTitle=Demande de vassalisation de
 FactionVassalizationRequestDeclinedNotificationBody=Votre faction a refusé une demande de vassalisation de la part de {0}.
 FactionVassalizationRequestRejectedNotificationTitle=Demande de vassalisation rejetée
 FactionVassalizationRequestRejectedNotificationBody={0} a refusé votre demande de vassalisation.
+CommandFactionPowerFactionClaims=Revendications de la faction : {0}/{1}
+CommandFactionPowerFactionClaimsUnlimited=Revendications de la faction : {0}

--- a/src/main/resources/lang/lang_pt_BR.properties
+++ b/src/main/resources/lang/lang_pt_BR.properties
@@ -1195,3 +1195,5 @@ FactionVassalizationRequestDeclinedNotificationTitle=Pedido de vassalagem de fac
 FactionVassalizationRequestDeclinedNotificationBody=Sua facção recusou um pedido de vassalagem de {0}.
 FactionVassalizationRequestRejectedNotificationTitle=Pedido de vassalagem rejeitado
 FactionVassalizationRequestRejectedNotificationBody={0} recusou seu pedido de vassalagem.
+CommandFactionPowerFactionClaims=Reivindica\u00e7\u00f5es da fac\u00e7\u00e3o: {0}/{1}
+CommandFactionPowerFactionClaimsUnlimited=Reivindica\u00e7\u00f5es da fac\u00e7\u00e3o: {0}

--- a/src/test/kotlin/com/dansplugins/factionsystem/command/faction/power/MfFactionPowerCommandTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/command/faction/power/MfFactionPowerCommandTest.kt
@@ -1,0 +1,203 @@
+package com.dansplugins.factionsystem.command.faction.power
+
+import com.dansplugins.factionsystem.MedievalFactions
+import com.dansplugins.factionsystem.TestUtils
+import com.dansplugins.factionsystem.claim.MfClaimService
+import com.dansplugins.factionsystem.claim.MfClaimedChunk
+import com.dansplugins.factionsystem.faction.MfFaction
+import com.dansplugins.factionsystem.faction.MfFactionService
+import com.dansplugins.factionsystem.faction.flag.MfFlag
+import com.dansplugins.factionsystem.faction.flag.MfFlagValues
+import com.dansplugins.factionsystem.faction.flag.MfFlags
+import com.dansplugins.factionsystem.lang.Language
+import com.dansplugins.factionsystem.player.MfPlayer
+import com.dansplugins.factionsystem.player.MfPlayerService
+import com.dansplugins.factionsystem.service.Services
+import org.bukkit.ChatColor
+import org.bukkit.Server
+import org.bukkit.configuration.file.FileConfiguration
+import org.bukkit.scheduler.BukkitScheduler
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import java.util.Locale
+import java.util.logging.Logger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MfFactionPowerCommandTest {
+    private val testUtils = TestUtils()
+
+    private lateinit var fixture: TestUtils.CommandTestFixture
+    private lateinit var plugin: MedievalFactions
+    private lateinit var factionService: MfFactionService
+    private lateinit var playerService: MfPlayerService
+    private lateinit var claimService: MfClaimService
+    private lateinit var language: Language
+    private lateinit var config: FileConfiguration
+    private lateinit var uut: MfFactionPowerCommand
+
+    @BeforeEach
+    fun setUp() {
+        fixture = testUtils.createCommandTestFixture()
+        plugin = mock(MedievalFactions::class.java)
+        mockServices()
+        mockLanguageSystem()
+        mockConfig()
+        mockScheduler()
+        mockLogger()
+        uut = MfFactionPowerCommand(plugin)
+    }
+
+    @Test
+    fun testOnCommand_senderWithoutPermission() {
+        // prepare
+        val sender = fixture.sender
+        val command = fixture.command
+        `when`(sender.hasPermission("mf.power")).thenReturn(false)
+        `when`(language["CommandFactionPowerNoPermission"]).thenReturn("No permission")
+
+        // execute
+        val result = uut.onCommand(sender, command, "label", arrayOf())
+
+        // verify
+        assertTrue(result)
+        verify(sender).sendMessage("${ChatColor.RED}No permission")
+    }
+
+    @Test
+    fun testOnCommand_consoleSenderWithoutViewOther() {
+        // prepare — a non-player sender without mf.power.view.other cannot resolve a target
+        val sender = fixture.sender
+        val command = fixture.command
+        `when`(sender.hasPermission("mf.power")).thenReturn(true)
+        `when`(sender.hasPermission("mf.power.view.other")).thenReturn(false)
+        `when`(language["CommandFactionPowerNotAPlayer"]).thenReturn("Not a player")
+
+        // execute
+        val result = uut.onCommand(sender, command, "label", arrayOf())
+
+        // verify
+        assertTrue(result)
+        verify(sender).sendMessage("${ChatColor.RED}Not a player")
+    }
+
+    @Test
+    fun testOnCommand_showsFactionClaimsWithCapacityWhenLandLimited() {
+        // prepare — a player viewing their own faction with factions.limitLand enabled
+        val player = fixture.player
+        val command = fixture.command
+        val mfPlayer = mock(MfPlayer::class.java)
+        val faction = mock(MfFaction::class.java)
+        `when`(player.hasPermission("mf.power")).thenReturn(true)
+        `when`(player.hasPermission("mf.power.view.other")).thenReturn(false)
+        `when`(playerService.getPlayer(player)).thenReturn(mfPlayer)
+        `when`(factionService.getFaction(mfPlayer.id)).thenReturn(faction)
+        stubFactionPower(faction, power = 5.0)
+        `when`(config.getBoolean("factions.limitLand")).thenReturn(true)
+        `when`(claimService.getClaims(faction.id)).thenReturn(
+            listOf(mock(MfClaimedChunk::class.java), mock(MfClaimedChunk::class.java), mock(MfClaimedChunk::class.java))
+        )
+        `when`(language["CommandFactionPowerFactionClaims", "3", "5"]).thenReturn("Faction claims: 3/5")
+
+        // execute
+        val result = uut.onCommand(player, command, "label", arrayOf())
+
+        // verify — the claims line reports used-of-capacity (capacity = floor(power))
+        assertTrue(result)
+        verify(player).sendMessage("${ChatColor.GRAY}Faction claims: 3/5")
+    }
+
+    @Test
+    fun testOnCommand_showsFactionClaimsWithoutCapacityWhenLandUnlimited() {
+        // prepare — same flow but factions.limitLand disabled, so no capacity is shown
+        val player = fixture.player
+        val command = fixture.command
+        val mfPlayer = mock(MfPlayer::class.java)
+        val faction = mock(MfFaction::class.java)
+        `when`(player.hasPermission("mf.power")).thenReturn(true)
+        `when`(player.hasPermission("mf.power.view.other")).thenReturn(false)
+        `when`(playerService.getPlayer(player)).thenReturn(mfPlayer)
+        `when`(factionService.getFaction(mfPlayer.id)).thenReturn(faction)
+        stubFactionPower(faction, power = 5.0)
+        `when`(config.getBoolean("factions.limitLand")).thenReturn(false)
+        `when`(claimService.getClaims(faction.id)).thenReturn(
+            listOf(mock(MfClaimedChunk::class.java), mock(MfClaimedChunk::class.java))
+        )
+        `when`(language["CommandFactionPowerFactionClaimsUnlimited", "2"]).thenReturn("Faction claims: 2")
+
+        // execute
+        val result = uut.onCommand(player, command, "label", arrayOf())
+
+        // verify
+        assertTrue(result)
+        verify(player).sendMessage("${ChatColor.GRAY}Faction claims: 2")
+    }
+
+    // Helper functions
+
+    private fun stubFactionPower(faction: MfFaction, power: Double) {
+        `when`(faction.power).thenReturn(power)
+        `when`(faction.maxPower).thenReturn(10.0)
+        `when`(faction.memberPower).thenReturn(power)
+        `when`(faction.maxMemberPower).thenReturn(10.0)
+        `when`(faction.vassalPower).thenReturn(0.0)
+        `when`(faction.maxVassalPower).thenReturn(0.0)
+        @Suppress("UNCHECKED_CAST")
+        val acceptBonusPowerFlag = mock(MfFlag::class.java) as MfFlag<Boolean>
+        val flags = mock(MfFlags::class.java)
+        val flagValues = mock(MfFlagValues::class.java)
+        `when`(plugin.flags).thenReturn(flags)
+        `when`(flags.acceptBonusPower).thenReturn(acceptBonusPowerFlag)
+        `when`(faction.flags).thenReturn(flagValues)
+        `when`(flagValues[acceptBonusPowerFlag]).thenReturn(false)
+    }
+
+    private fun mockServices() {
+        val services = mock(Services::class.java)
+        `when`(plugin.services).thenReturn(services)
+
+        factionService = mock(MfFactionService::class.java)
+        `when`(services.factionService).thenReturn(factionService)
+
+        playerService = mock(MfPlayerService::class.java)
+        `when`(services.playerService).thenReturn(playerService)
+
+        claimService = mock(MfClaimService::class.java)
+        `when`(services.claimService).thenReturn(claimService)
+    }
+
+    private fun mockLanguageSystem() {
+        language = mock(Language::class.java)
+        `when`(plugin.language).thenReturn(language)
+        `when`(language.locale).thenReturn(Locale.ENGLISH)
+    }
+
+    private fun mockConfig() {
+        config = mock(FileConfiguration::class.java)
+        `when`(plugin.config).thenReturn(config)
+    }
+
+    private fun mockScheduler() {
+        val server = mock(Server::class.java)
+        `when`(plugin.server).thenReturn(server)
+
+        val scheduler = mock(BukkitScheduler::class.java)
+        `when`(server.scheduler).thenReturn(scheduler)
+        // Run the dispatched task synchronously so the command body executes within the test.
+        `when`(scheduler.runTaskAsynchronously(eq(plugin), any(Runnable::class.java))).thenAnswer { invocation ->
+            (invocation.arguments[1] as Runnable).run()
+            null
+        }
+    }
+
+    private fun mockLogger() {
+        val logger = mock(Logger::class.java)
+        `when`(plugin.logger).thenReturn(logger)
+    }
+}


### PR DESCRIPTION
## Summary
- `/faction power` now reports a faction's claim count alongside its power. When `factions.limitLand` is enabled, the count is shown as `claimed/capacity`, where the capacity equals the faction's current power (the same value that gates claiming). When `limitLand` is disabled — so land isn't power-bounded — only the claimed-chunk count is shown.
- Resolves the request in #1901 to surface "the amount of claims you have out of the most capable" by modifying the power command's response.

## Changes
- `MfFactionPowerCommand`: emit a claims line after the existing faction-power line, branching on `factions.limitLand`.
- New language keys `CommandFactionPowerFactionClaims` and `CommandFactionPowerFactionClaimsUnlimited` added to all five locales (en_US, en_GB, de_DE, fr_FR, pt_BR). Additive only; pt_BR uses `\u` escapes to stay encoding-safe in the Latin-1 files.
- `COMMANDS.md` and `CHANGELOG.md` updated.
- `MfFactionPowerCommandTest` (new): exercises both the limited (`claimed/capacity`) and unlimited (`claimed`) lines by running the command's dispatched async task with mocked services, plus the no-permission and non-player guard branches.

## Test plan
- [x] `MfFactionPowerCommandTest` — limited path asserts `Faction claims: 3/5` (3 claims, power 5).
- [x] `MfFactionPowerCommandTest` — unlimited path asserts `Faction claims: 2`.
- [x] Guard branches: no-permission and console-without-`mf.power.view.other`.
- [ ] CI `build` + `docker-build` green (external anchor).

## Data-safety statement
No schema migrations; no DPC contract change; no `config.yml` default change; no `plugin.yml` change. Read-only display feature — reads existing claim/power state, mutates nothing. Lang changes are additive (no key removals).

Closes #1901

---

_drafted by Claude on behalf of Daniel Stephenson_