### PR TITLE
Stop pressure plates from flooding chat with protection messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - bStats charts for DPC opt-in rate, login-reminder usage, server-IP sharing, and Discord-link presence.
 
 ### Fixed
+- Standing on a pressure plate (or tripwire, or farmland) you are not allowed to use no longer floods chat with a protection message every tick. Physical interactions are still blocked exactly as before; only the accompanying message is suppressed, for the faction-territory, wilderness and bypass notices alike.
 - Faction snapshot for the DPC sync is now collected on the Bukkit main thread before being dispatched off-thread via `HttpClient.sendAsync`. Off-thread access to `factionService.factions` could otherwise produce inconsistent reads or `ConcurrentModificationException` under load.
 - The DPC sync no longer POSTs an empty faction roster. A transient empty read (e.g. faction data not yet loaded at startup, or a reload mid-cycle) is skipped client-side rather than sent, so it can never depend on the provider's safety guards to avoid a faction wipe.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -123,7 +123,7 @@ Controls behavior and alerts in unclaimed wilderness areas.
 ### `wilderness.interaction.alert`
 **Type:** Boolean  
 **Default:** `false`  
-**Description:** When `true`, sends an alert message when players interact with blocks in wilderness.
+**Description:** When `true`, sends an alert message when players interact with blocks in wilderness. No alert is sent for physical interactions (stepping on a pressure plate or tripwire, trampling farmland), which repeat every tick and would flood chat; the interaction is still prevented.
 
 ### `wilderness.place.prevent`
 **Type:** Boolean  

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
@@ -107,6 +107,11 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         val claimService = plugin.services.claimService
         val mfPlayer = playerService.getPlayer(event.player)
 
+        // Physical interactions (pressure plates, tripwire, farmland) fire once per tick for as long as
+        // the player is stood on the block, so notifying on each one floods the player's chat. The
+        // interaction is still cancelled - only the message is suppressed.
+        val suppressProtectionMessages = event.action == PHYSICAL
+
         if (mfPlayer == null) {
             event.isCancelled = true
             plugin.server.scheduler.runTaskAsynchronously(
@@ -182,7 +187,7 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         if (claim == null) {
             if (plugin.config.getBoolean("wilderness.interaction.prevent", false)) {
                 event.isCancelled = true
-                if (plugin.config.getBoolean("wilderness.interaction.alert", true)) {
+                if (plugin.config.getBoolean("wilderness.interaction.alert", true) && !suppressProtectionMessages) {
                     event.player.sendMessage("$RED${plugin.language["CannotInteractBlockInWilderness"]}")
                 }
             }
@@ -201,7 +206,9 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
         // Check if player is allowed to interact based on faction relationships
         if (!claimService.isInteractionAllowed(mfPlayer.id, claim)) {
             if (mfPlayer.isBypassEnabled && event.player.hasPermission("mf.bypass")) {
-                event.player.sendMessage("$RED${plugin.language["FactionTerritoryProtectionBypassed"]}")
+                if (!suppressProtectionMessages) {
+                    event.player.sendMessage("$RED${plugin.language["FactionTerritoryProtectionBypassed"]}")
+                }
             } else {
                 // Check if player is at war and trying to place a ladder
                 // Only allow if they're right-clicking with a ladder on a solid, non-interactable block
@@ -234,7 +241,9 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
                     }
                 }
                 event.isCancelled = true
-                event.player.sendMessage("$RED${plugin.language["CannotInteractWithBlockInFactionTerritory", claimFaction.name]}")
+                if (!suppressProtectionMessages) {
+                    event.player.sendMessage("$RED${plugin.language["CannotInteractWithBlockInFactionTerritory", claimFaction.name]}")
+                }
             }
         }
     }

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -431,9 +431,10 @@ class PlayerInteractListenerTest {
         // Act
         uut.onPlayerInteract(fixture.event)
 
-        // Assert - physical action with ladder should not bypass protection
+        // Assert - physical action with ladder should not bypass protection.
+        // No message is sent because physical interactions repeat every tick (see #1957).
         verifyEventCancelled()
-        verifyPlayerNotified()
+        verifyPlayerNotNotified()
     }
 
     @Test
@@ -972,6 +973,106 @@ class PlayerInteractListenerTest {
         verifyPlayerNotified()
     }
 
+    // --- Physical interaction tests ---
+
+    @Test
+    fun onPlayerInteract_PhysicalActionInFactionTerritory_ShouldCancelWithoutNotifyingPlayer() {
+        // Regression test for #1957: a pressure plate fires a PHYSICAL interaction on every tick the
+        // player stands on it, so notifying on each one floods chat. The interaction must still be
+        // cancelled - only the message is suppressed.
+        // Arrange
+        mockBlockData<BlockData>()
+        setupConfigForDoorInteraction(enabled = false)
+        val (_, playerId) = setupPlayerMocks(fixture.player)
+        val (claim, _) = setupClaimAndFaction(fixture.block)
+
+        `when`(claimService.isInteractionAllowed(playerId, claim)).thenReturn(false)
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - protection still applies, but the player is not spammed
+        verifyEventCancelled()
+        verifyPlayerNotNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_RightClickInFactionTerritory_ShouldCancelAndNotifyPlayer() {
+        // Contrast case for #1957: a deliberate right-click happens once, so the player is still told
+        // why the interaction was blocked.
+        // Arrange
+        mockBlockData<BlockData>()
+        setupConfigForDoorInteraction(enabled = false)
+        val (_, playerId) = setupPlayerMocks(fixture.player)
+        val (claim, _) = setupClaimAndFaction(fixture.block)
+
+        `when`(claimService.isInteractionAllowed(playerId, claim)).thenReturn(false)
+        `when`(fixture.event.action).thenReturn(Action.RIGHT_CLICK_BLOCK)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert
+        verifyEventCancelled()
+        verifyPlayerNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_PhysicalActionInWilderness_WildernessPreventInteractionSetToTrue_ShouldCancelWithoutNotifyingPlayer() {
+        // The same per-tick flood applies to pressure plates in wilderness when
+        // wilderness.interaction.prevent is enabled.
+        // Arrange
+        val block = fixture.block
+        val player = fixture.player
+        val event = fixture.event
+
+        val blockData = mock(BlockData::class.java)
+        `when`(block.blockData).thenReturn(blockData)
+
+        val mfPlayer = mock(MfPlayer::class.java)
+        val playerId = MfPlayerId(player.uniqueId.toString())
+        `when`(mfPlayer.id).thenReturn(playerId)
+
+        `when`(event.clickedBlock).thenReturn(block)
+        `when`(event.action).thenReturn(Action.PHYSICAL)
+        `when`(playerService.getPlayer(player)).thenReturn(mfPlayer)
+        `when`(interactionService.getInteractionStatus(playerId)).thenReturn(null)
+        `when`(claimService.getClaim(block.chunk)).thenReturn(null)
+        `when`(medievalFactions.config).thenReturn(mock(FileConfiguration::class.java))
+        `when`(medievalFactions.config.getBoolean("wilderness.interaction.prevent", false)).thenReturn(true)
+        `when`(medievalFactions.config.getBoolean("wilderness.interaction.alert", true)).thenReturn(true)
+
+        // Act
+        uut.onPlayerInteract(event)
+
+        // Assert
+        verifyEventCancelled()
+        verifyPlayerNotNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_PhysicalActionWithBypassEnabled_ShouldNotNotifyPlayer() {
+        // The bypass notice is sent on every blocked-then-bypassed interaction, so it floods an
+        // admin's chat for exactly the same reason.
+        // Arrange
+        mockBlockData<BlockData>()
+        setupConfigForDoorInteraction(enabled = false)
+        val (_, playerId) = setupPlayerMocks(fixture.player, bypassEnabled = true)
+        val (claim, _) = setupClaimAndFaction(fixture.block)
+
+        `when`(claimService.isInteractionAllowed(playerId, claim)).thenReturn(false)
+        `when`(fixture.player.hasPermission("mf.bypass")).thenReturn(true)
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - bypass still applies, but without the per-tick notice
+        verifyEventNotCancelled()
+        verifyPlayerNotNotified()
+    }
+
     // Helper functions
 
     private inline fun <reified T> mockBlockData() {
@@ -1161,6 +1262,10 @@ class PlayerInteractListenerTest {
 
     private fun verifyPlayerNotified() {
         verify(fixture.player).sendMessage(any(String::class.java))
+    }
+
+    private fun verifyPlayerNotNotified() {
+        verify(fixture.player, never()).sendMessage(any(String::class.java))
     }
 
     private data class PlayerInteractListenerTestFixture(


### PR DESCRIPTION
## Summary

`PlayerInteractEvent` with `Action.PHYSICAL` (pressure plates, tripwire, farmland, turtle eggs) fires **once per tick** for as long as a player stands on the block. `PlayerInteractListener.applyProtections` sent a protection message on every one of those events, so a player stood on a pressure plate inside a claim they cannot interact with received ~20 messages/second — enough to drop the reporter from 120+ FPS to unplayable, and worse with several plates at once.

This suppresses the *message* for physical interactions only. **The interaction is still cancelled exactly as before** — no protection behaviour changes.

Suppressed at three sites, all reachable from a physical interaction:
- `CannotInteractWithBlockInFactionTerritory` (the reported case)
- `CannotInteractBlockInWilderness` (same flood when `wilderness.interaction.prevent` is on)
- `FactionTerritoryProtectionBypassed` (same flood for an admin with `mf.bypass` active)

## Test plan

- [x] `onPlayerInteract_PhysicalActionInFactionTerritory_ShouldCancelWithoutNotifyingPlayer` — cancelled, no message
- [x] `onPlayerInteract_RightClickInFactionTerritory_ShouldCancelAndNotifyPlayer` — contrast case, deliberate clicks are still explained
- [x] `onPlayerInteract_PhysicalActionInWilderness_...ShouldCancelWithoutNotifyingPlayer`
- [x] `onPlayerInteract_PhysicalActionWithBypassEnabled_ShouldNotNotifyPlayer`
- [x] `onPlayerInteract_LadderInHand_PhysicalAction_ShouldNotBypass` updated — it asserted a message *was* sent on a physical action; it now asserts the event is still cancelled and no message is sent. The protection assertion (`verifyEventCancelled`) is unchanged; only the message expectation moved with the intended behaviour.
- [ ] Manual: stand on a pressure plate in another faction's claim — no chat, plate still does not fire

## Verification anchor

**Local `./gradlew` could not run:** this checkout's only JDK is Java 21 (class file major 65) and the Gradle 7.6.4 wrapper rejects it (`Unsupported class file major version 65`); no Docker is available for the container fallback. Per the loop's UNVERIFIED rule, **the CI `build` check on this PR's head SHA is the anchor** — the changed files are squarely in CI's scope (Kotlin main + test sources), so the PR is not merge-ready until that check is green.

## Data-safety statement

No schema migrations; no DPC contract change; no `config.yml` change; no `plugin.yml` change; no `lang/` change (no new strings — the affected messages already exist and are still used for non-physical interactions).

## Deferred this cycle

Everything else in the open backlog was deferred because this cycle was scoped to a single well-bounded bug. Two things found while working here and worth their own cycle:

- **#1970** (`PlayerInteractListener` wartime `Action` gating) touches the same file but is a protection-semantics refactor that re-opens the #1968 exploit surface if resolved carelessly; it also asks for a curated "interactive block" set to replace Bukkit's `Material.isInteractable`, which is a real behaviour change. It deserves an undivided cycle.
- The `PlayerInteractListenerTest` fixture gives `block`, `block.getRelative(UP)` and `block.getRelative(DOWN)` all the same coordinates (`0,0,0`) in the same world, so they produce equal `MfBlockPosition` values. `setupLockedBlock` therefore has its `getLockedBlock` stub overwritten by its own `null` stub for the block above, and the locked-block tests never actually see a locked block. Filed separately; a physical-interaction test for the locked-block message path was dropped from this PR rather than built on that fixture.

Closes #1957

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
