### PR TITLE
chore: bump version to 6.0.0-SNAPSHOT-7-25-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [6.0.0] – 2026-07-25
+## [6.0.0-SNAPSHOT-7-25-2026] – 2026-07-25
 
 ### Changed
-- Medieval Factions is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in the plugin API, the configuration format or the database schema, and 5.x servers can upgrade in place.
+- Medieval Factions is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in the plugin API, the configuration format or the database schema, and 5.x servers can upgrade in place. Released as `6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live server operation, and the dated snapshot designation stays until it has.
 
 ### Added
 - Configurable moderator approval for faction declarations. When enabled, `/faction declarewar`, `/faction ally`, and `/faction vassalize` create a pending request that a moderator (permission `mf.approve`, default `op`) must approve before it takes effect. Gated independently by the `factions.warDeclarationRequiresApproval`, `factions.allyDeclarationRequiresApproval`, and `factions.vassalizeDeclarationRequiresApproval` config options (all default `false`). New `/faction approve [id]`, `/faction deny [id]`, and `/faction pendingactions` commands manage requests, and a reason can be attached with `-- <reason>`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [6.0.0] – 2026-07-25
+
+### Changed
+- Medieval Factions is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The major version bump marks that change in how the project is built — it is not a break in the plugin API, the configuration format or the database schema, and 5.x servers can upgrade in place.
 
 ### Added
 - Configurable moderator approval for faction declarations. When enabled, `/faction declarewar`, `/faction ally`, and `/faction vassalize` create a pending request that a moderator (permission `mf.approve`, default `op`) must approve before it takes effect. Gated independently by the `factions.warDeclarationRequiresApproval`, `factions.allyDeclarationRequiresApproval`, and `factions.vassalizeDeclarationRequiresApproval` config options (all default `false`). New `/faction approve [id]`, `/faction deny [id]`, and `/faction pendingactions` commands manage requests, and a reason can be attached with `-- <reason>`.

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.dansplugins"
-version = "5.9.0-SNAPSHOT"
+version = "6.0.0"
 
 def repoUsername = ""
 def repoPassword = ""

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "com.dansplugins"
-version = "6.0.0"
+version = "6.0.0-SNAPSHOT-7-25-2026"
 
 def repoUsername = ""
 def repoPassword = ""


### PR DESCRIPTION
## Summary

Bumps Medieval Factions from `5.9.0-SNAPSHOT` to **`6.0.0-SNAPSHOT-7-25-2026`** and promotes the accumulated `[Unreleased]` CHANGELOG section to a dated heading under that version.

## Why a major version, and why a dated snapshot

The major increment marks Medieval Factions moving to an **AI-first development approach**. Day-to-day feature work, grooming, review and maintenance now run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The 6.x line reflects that change in how the project is built.

It is shipped as a **dated snapshot rather than a finished `6.0.0`** because the AI-first line has not yet been verified in live server operation. The designation stays until it has. This follows the repo's existing prerelease naming (`4.7.0-SNAPSHOT-10-6-2022`, `4.6.4-ALPHA-3-27-2022`) rather than inventing a new scheme.

It is **not** a compatibility break: the plugin API, the `config.yml` format and the database schema are unchanged from 5.x, and existing servers can upgrade in place.

## Where the version lives

`build.gradle` is the single source of truth. `src/main/resources/plugin.yml` and `src/main/resources/config.yml` declare `version: @version@`, which `processResources` substitutes at build time via `ReplaceTokens`. No version constant exists in Kotlin/Java source, and `gradle.properties` does not carry one — so `build.gradle:10` was the only file that needed editing.

| File | Line | Before | After |
| --- | --- | --- | --- |
| `build.gradle` | 10 | `version = "5.9.0-SNAPSHOT"` | `version = "6.0.0-SNAPSHOT-7-25-2026"` |
| `CHANGELOG.md` | 7 | `## [Unreleased]` | `## [6.0.0-SNAPSHOT-7-25-2026] – 2026-07-25` + a `### Changed` entry |

## Verification

**CI is green on the current head** (`3085aaa1`): `build` passed in 3m4s and `docker-build` in 7m12s, on the JDK 17 the project's toolchain nominates. That is the authoritative check.

An earlier local run against the `6.0.0` spelling of this branch also passed `processResources`, `compileKotlin` and `shadowJar`, with `plugin.yml`/`config.yml` rendering the substituted version — but it ran with JDK 11 as the Gradle launcher, since JDK 17 is not installed in that environment and Gradle 7.6.4 rejects the installed JDK 21 outright (`Unsupported class file major version 65`). The local run was **not** repeated after the rename to the dated snapshot; CI above covers that commit.

## Notes for review

Several open PRs also touch `build.gradle` (#1948, #1944, #1915) or `CHANGELOG.md` (#1919). None of them change the version declaration, but whichever merges second may need a trivial rebase.

Merging this is intended to be followed by tagging `6.0.0-SNAPSHOT-7-25-2026` on `main` and cutting a pre-release from it.

---

_drafted by Claude on behalf of Daniel Stephenson_