### PR TITLE
Stop locked blocks flooding chat on physical interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+- Standing on a *locked* pressure plate (or tripwire, or farmland) you are not allowed to use no longer floods chat with a lock message every tick. This covers the one path missed by the previous physical-interaction fix, and it also stops the per-tick scheduled task and block-owner lookup that each of those messages performed. The lock protection itself is unchanged — the interaction is still blocked.
+
 ## [6.0.0-SNAPSHOT-7-25-2026] – 2026-07-25
 
 ### Changed

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
@@ -151,21 +151,27 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
             if (event.player.uniqueId.toString() !in (lockedBlock.accessors + lockedBlock.playerId).map(MfPlayerId::value)) {
                 // Check if player has bypass permission from mf.bypass or faction permission
                 if ((mfPlayer.isBypassEnabled && event.player.hasPermission("mf.bypass")) || hasLockBypassPermission(mfPlayer)) {
-                    plugin.server.scheduler.runTaskAsynchronously(
-                        plugin,
-                        Runnable {
-                            val owner = playerService.getPlayer(lockedBlock.playerId)
-                            event.player.sendMessage("$RED${plugin.language["LockProtectionBypassed", owner?.toBukkit()?.name ?: plugin.language["UnknownPlayer"]]}")
-                        }
-                    )
+                    // The whole task is skipped when suppressing, not just the message: each one performs
+                    // an owner lookup, so scheduling it per tick is the expensive half of the problem.
+                    if (!suppressProtectionMessages) {
+                        plugin.server.scheduler.runTaskAsynchronously(
+                            plugin,
+                            Runnable {
+                                val owner = playerService.getPlayer(lockedBlock.playerId)
+                                event.player.sendMessage("$RED${plugin.language["LockProtectionBypassed", owner?.toBukkit()?.name ?: plugin.language["UnknownPlayer"]]}")
+                            }
+                        )
+                    }
                 } else {
-                    plugin.server.scheduler.runTaskAsynchronously(
-                        plugin,
-                        Runnable {
-                            val owner = playerService.getPlayer(lockedBlock.playerId)
-                            event.player.sendMessage("$RED${plugin.language["BlockLocked", owner?.toBukkit()?.name ?: plugin.language["UnknownPlayer"]]}")
-                        }
-                    )
+                    if (!suppressProtectionMessages) {
+                        plugin.server.scheduler.runTaskAsynchronously(
+                            plugin,
+                            Runnable {
+                                val owner = playerService.getPlayer(lockedBlock.playerId)
+                                event.player.sendMessage("$RED${plugin.language["BlockLocked", owner?.toBukkit()?.name ?: plugin.language["UnknownPlayer"]]}")
+                            }
+                        )
+                    }
                     event.isCancelled = true
                 }
                 return

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -17,6 +17,7 @@ import com.dansplugins.factionsystem.player.MfPlayerId
 import com.dansplugins.factionsystem.player.MfPlayerService
 import com.dansplugins.factionsystem.relationship.MfFactionRelationshipService
 import org.bukkit.Material
+import org.bukkit.Server
 import org.bukkit.World
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
@@ -29,10 +30,14 @@ import org.bukkit.event.block.Action
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
+import org.bukkit.scheduler.BukkitScheduler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.atLeast
 import org.mockito.Mockito.doReturn
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -84,6 +89,7 @@ class PlayerInteractListenerTest {
     private lateinit var lockService: MfLockService
     private lateinit var relationshipService: MfFactionRelationshipService
     private lateinit var factionService: com.dansplugins.factionsystem.faction.MfFactionService
+    private lateinit var scheduler: BukkitScheduler
     private lateinit var uut: PlayerInteractListener
 
     // Common test constants
@@ -96,6 +102,7 @@ class PlayerInteractListenerTest {
         medievalFactions = mock(MedievalFactions::class.java)
         mockServices()
         mockLanguageSystem()
+        mockScheduler()
         uut = PlayerInteractListener(medievalFactions)
     }
 
@@ -215,8 +222,32 @@ class PlayerInteractListenerTest {
         // Act
         uut.onPlayerInteract(fixture.event)
 
-        // Assert - event should NOT be cancelled because player has bypass enabled
+        // Assert - event should NOT be cancelled because player has bypass enabled, and the bypass
+        // notice is sent once for the deliberate right-click
         verifyEventNotCancelled()
+        runScheduledAsyncTasks()
+        verifyPlayerNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_LockedBlock_NonOwnerWithoutBypass_ShouldCancelAndNotifyPlayer() {
+        // Arrange
+        mockBlockData<Door>()
+        setupConfigForDoorInteraction(enabled = false)
+        setupPlayerMocks(fixture.player, bypassEnabled = false)
+
+        // Create a locked block owned by a different player
+        setupLockedBlock(ownedByPlayer = false, playerIsAccessor = false)
+
+        `when`(fixture.player.hasPermission("mf.bypass")).thenReturn(false)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - lock protection applies and the player is told why
+        verifyEventCancelled()
+        runScheduledAsyncTasks()
+        verifyPlayerNotified()
     }
 
     @Test
@@ -232,8 +263,9 @@ class PlayerInteractListenerTest {
         // Act
         uut.onPlayerInteract(fixture.event)
 
-        // Assert - event should NOT be cancelled because player is an accessor
+        // Assert - event should NOT be cancelled because player is an accessor, and no notice is sent
         verifyEventNotCancelled()
+        verifyNoAsyncTaskScheduled()
     }
 
     @Test
@@ -1073,6 +1105,49 @@ class PlayerInteractListenerTest {
         verifyPlayerNotNotified()
     }
 
+    @Test
+    fun onPlayerInteract_PhysicalActionOnLockedBlock_ShouldCancelWithoutSchedulingOwnerLookup() {
+        // Regression test for #1978: a locked pressure plate produced not just a message per tick, but a
+        // scheduled async task and an owner lookup per tick. The lock protection itself must not change.
+        // Arrange
+        mockBlockData<BlockData>()
+        setupConfigForDoorInteraction(enabled = false)
+        setupPlayerMocks(fixture.player, bypassEnabled = false)
+        setupLockedBlock(ownedByPlayer = false, playerIsAccessor = false)
+
+        `when`(fixture.player.hasPermission("mf.bypass")).thenReturn(false)
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - still blocked, but no per-tick task, lookup or message
+        verifyEventCancelled()
+        verifyNoAsyncTaskScheduled()
+        verifyPlayerNotNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_PhysicalActionOnLockedBlockWithBypassEnabled_ShouldNotScheduleOwnerLookup() {
+        // The bypass notice on a locked block floods for the same reason as the blocked notice.
+        // Arrange
+        mockBlockData<BlockData>()
+        setupConfigForDoorInteraction(enabled = false)
+        setupPlayerMocks(fixture.player, bypassEnabled = true)
+        setupLockedBlock(ownedByPlayer = false, playerIsAccessor = false)
+
+        `when`(fixture.player.hasPermission("mf.bypass")).thenReturn(true)
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - bypass still applies, without the per-tick task
+        verifyEventNotCancelled()
+        verifyNoAsyncTaskScheduled()
+        verifyPlayerNotNotified()
+    }
+
     // Helper functions
 
     private inline fun <reified T> mockBlockData() {
@@ -1124,10 +1199,12 @@ class PlayerInteractListenerTest {
         // Mock the lockService to return our locked block for the specific block position
         doReturn(lockedBlock).`when`(lockService).getLockedBlock(blockPosition)
 
-        // Mock the upward block position as well for bisected blocks
-        val upBlock = fixture.block.getRelative(BlockFace.UP)
-        val upBlockPosition = MfBlockPosition.fromBukkitBlock(upBlock)
-        doReturn(null).`when`(lockService).getLockedBlock(upBlockPosition)
+        // Mock the neighbouring block positions as well, since bisected blocks are looked up as a pair
+        // with either their upper or their lower half.
+        listOf(BlockFace.UP, BlockFace.DOWN).forEach { face ->
+            val neighbour = fixture.block.getRelative(face)
+            doReturn(null).`when`(lockService).getLockedBlock(MfBlockPosition.fromBukkitBlock(neighbour))
+        }
     }
 
     private fun setupClaimAndFaction(block: Block): Pair<MfClaimedChunk, MfFactionId> {
@@ -1226,11 +1303,13 @@ class PlayerInteractListenerTest {
 
     private fun createBasicFixture(): PlayerInteractListenerTestFixture {
         val world = testUtils.createMockWorld()
-        val block = testUtils.createMockBlock(world)
+        val block = testUtils.createMockBlock(world, 0, 0, 0)
 
-        // Mock blocks for UP and DOWN directions
-        val blockAbove = testUtils.createMockBlock(world)
-        val blockBelow = testUtils.createMockBlock(world)
+        // Mock blocks for UP and DOWN directions. These must have distinct coordinates: MfBlockPosition
+        // is a data class over (worldId, x, y, z), so neighbours left at the default (0, 0, 0) would
+        // collapse onto the clicked block's position and overwrite its lockService stub.
+        val blockAbove = testUtils.createMockBlock(world, 0, 1, 0)
+        val blockBelow = testUtils.createMockBlock(world, 0, -1, 0)
 
         // Set up relative block retrieval
         `when`(block.getRelative(BlockFace.UP)).thenReturn(blockAbove)
@@ -1296,6 +1375,28 @@ class PlayerInteractListenerTest {
     private fun mockLanguageSystem() {
         val language = mock(Language::class.java)
         `when`(language.get(anyString(), anyString())).thenReturn("Cannot interact with block in faction territory")
+        `when`(language["UnknownPlayer"]).thenReturn("Unknown player")
         `when`(medievalFactions.language).thenReturn(language)
+    }
+
+    private fun mockScheduler() {
+        val server = mock(Server::class.java)
+        scheduler = mock(BukkitScheduler::class.java)
+        `when`(medievalFactions.server).thenReturn(server)
+        `when`(server.scheduler).thenReturn(scheduler)
+    }
+
+    /**
+     * Runs every [Runnable] that was dispatched to the async scheduler, so that the logic inside it is
+     * actually exercised rather than only asserted to have been scheduled.
+     */
+    private fun runScheduledAsyncTasks() {
+        val captor = ArgumentCaptor.forClass(Runnable::class.java)
+        verify(scheduler, atLeast(0)).runTaskAsynchronously(eq(medievalFactions), captor.capture())
+        captor.allValues.forEach { it.run() }
+    }
+
+    private fun verifyNoAsyncTaskScheduled() {
+        verify(scheduler, never()).runTaskAsynchronously(eq(medievalFactions), any(Runnable::class.java))
     }
 }

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -1201,9 +1201,12 @@ class PlayerInteractListenerTest {
 
         // Mock the neighbouring block positions as well, since bisected blocks are looked up as a pair
         // with either their upper or their lower half.
-        listOf(BlockFace.UP, BlockFace.DOWN).forEach { face ->
-            val neighbour = fixture.block.getRelative(face)
-            doReturn(null).`when`(lockService).getLockedBlock(MfBlockPosition.fromBukkitBlock(neighbour))
+        // The position must be resolved before the doReturn(...) call: reading the neighbour mock's
+        // coordinates part-way through stubbing lockService raises UnfinishedStubbingException.
+        val neighbourPositions = listOf(BlockFace.UP, BlockFace.DOWN)
+            .map { face -> MfBlockPosition.fromBukkitBlock(fixture.block.getRelative(face)) }
+        neighbourPositions.forEach { position ->
+            doReturn(null).`when`(lockService).getLockedBlock(position)
         }
     }
 


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- **#1978 — locked blocks still flood chat on physical interactions.** PR #1976 suppressed the per-tick protection message for `Action.PHYSICAL` in the wilderness, faction-territory and bypass-notice branches of `PlayerInteractListener.applyProtections`, but not in the **locked-block** branch that runs earlier in the same function. `lock()` applies no block-type restriction, so a player can `/mf lock` a pressure plate, tripwire or farmland block — and a non-accessor standing on it got one message *per tick*, each emitted from a `runTaskAsynchronously` block doing a `playerService.getPlayer(...)` owner lookup. This reuses the existing `suppressProtectionMessages` flag and skips **scheduling the task at all**, so the per-tick lookup goes away too. `event.isCancelled = true` stays outside the guard — the protection itself is unchanged.
- **#1977 — locked-block tests were vacuous.** `MfBlockPosition` is a data class over `(worldId, x, y, z)` and `TestUtils.createMockBlock` defaults every block to `(0, 0, 0)`, so the clicked block and its `UP`/`DOWN` neighbours mapped to the *same* position. `setupLockedBlock`'s second stub therefore overwrote the first with `null`, and no test ever reached the locked-block branch — the two existing locked-block tests passed for the wrong reason and would have kept passing if lock protection were deleted. Neighbours now get real coordinates and both faces are stubbed.
- As #1977 predicted, that fix alone makes the tests NPE, because `medievalFactions.server` was never mocked. Added a `mockScheduler()` following the existing `BlockBreakListenerTest` pattern, plus a `runScheduledAsyncTasks()` helper that **captures and runs** the dispatched `Runnable`s so the message logic is genuinely exercised rather than merely asserted to have been scheduled.

### Test coverage added

| Test | Asserts |
|---|---|
| `LockedBlock_NonOwnerWithoutBypass_ShouldCancelAndNotifyPlayer` | new — the locked-block branch is actually reached: cancelled, and the message is sent when the captured task runs |
| `PhysicalActionOnLockedBlock_ShouldCancelWithoutSchedulingOwnerLookup` | new — regression guard for #1978: still cancelled, **no** task scheduled, no message |
| `PhysicalActionOnLockedBlockWithBypassEnabled_ShouldNotScheduleOwnerLookup` | new — same for the bypass notice |
| `LockedBlock_NonOwnerWithBypassEnabled_ShouldAllowInteraction` | strengthened — now runs the captured task and asserts the player *is* notified on a deliberate right-click |
| `LockedBlock_PlayerIsAccessor_ShouldAllowInteraction` | strengthened — asserts no task is scheduled for an accessor |

## Test plan

- [x] `build` green in CI on head `8a690cf3` — 355 tests completed, 0 failed ([run 30215890703](https://github.com/Dans-Plugins/Medieval-Factions/actions/runs/30215890703))
- [x] `docker-build` green on the same run
- [x] **Regression evidence (empirical, not reasoned):** the fix was temporarily reverted on this branch (`a86e1041`, since force-pushed away) and CI failed with *exactly* the two new `PhysicalAction…LockedBlock…` tests and nothing else ([run 30216194956](https://github.com/Dans-Plugins/Medieval-Factions/actions/runs/30216194956), 355 tests, 2 failed). The branch was reset to `8a690cf3` and re-verified green.
- [x] Existing physical-interaction tests from #1976 (faction territory, wilderness, bypass) untouched and still asserting the same behavior

**Anchor note:** local `./gradlew` cannot run in this environment (Gradle 7.6.4 vs the only available JVM: `Unsupported class file major version 65`), and no container runtime is available. Per the loop's UNVERIFIED rule the anchor is the **CI check on this PR's head SHA**, not a local run. The changed files are Kotlin sources fully inside the Gradle build, so CI's scope does cover them.

## Data safety

No schema migrations; no DPC contract change; no `config.yml` / `plugin.yml` / `lang/` change. No new user-facing strings — the existing `BlockLocked`, `LockProtectionBypassed` and `UnknownPlayer` keys are reused unmodified. The only production change is a conditional around two `runTaskAsynchronously` calls; the `event.isCancelled = true` that enforces lock protection is deliberately left outside it. No modified path matches the do-not-auto-merge list.

## Reviewer note

Suppressing the *bypass* notice on physical interactions makes it silent for admins, not merely throttled. That mirrors what #1976 already did to the faction-territory bypass notice, but it is a behavior change worth an explicit nod. Full reasoning, and three other judgment calls, are in the self-review comment below.

## Filed, not fixed here

#1981 — the `mfPlayer == null` branch of the same function also schedules an async player save per tick for an unregistered player. Same per-tick shape, unrelated to locks, left out to keep this PR scoped.

## Deferred this cycle

The rest of the open backlog was not touched: this cycle was scoped to the #1977/#1978 pair, which have a dependency relationship (#1977 is the prerequisite for testing #1978) and were the freshest, best-specified issues. The remaining open issues are feature requests, unreproduced user bug reports, or (in the case of #1943 / #1914 / #1947) already have open `copilot/*` PRs.

Closes #1977
Closes #1978

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
