### PR TITLE
Dedupe async player-save on repeated physical interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Standing on a *locked* pressure plate (or tripwire, or farmland) you are not allowed to use no longer floods chat with a lock message every tick. This covers the one path missed by the previous physical-interaction fix, and it also stops the per-tick scheduled task and block-owner lookup that each of those messages performed. The lock protection itself is unchanged — the interaction is still blocked.
+- A player with no `MfPlayer` record yet who stands on a protected physical block (pressure plate, tripwire, farmland) no longer queues a duplicate async player-save every tick. Only the first physical interaction dispatches a save; further ticks are ignored until that save completes.
 
 ## [6.0.0-SNAPSHOT-7-25-2026] – 2026-07-25
 

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
@@ -37,10 +37,16 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.Action.PHYSICAL
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.EquipmentSlot.HAND
+import java.util.concurrent.ConcurrentHashMap
 import java.util.logging.Level.SEVERE
 import org.bukkit.block.data.type.Gate as FenceGateData
 
 class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
+
+    // Tracks players whose MfPlayer record is currently being created asynchronously, so that
+    // Action.PHYSICAL (which fires once per tick while the player stands on the block) doesn't
+    // queue a duplicate save for every tick until the first one completes.
+    private val playersWithPendingSave: MutableSet<MfPlayerId> = ConcurrentHashMap.newKeySet()
 
     @EventHandler
     fun onPlayerInteract(event: PlayerInteractEvent) {
@@ -114,16 +120,23 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
 
         if (mfPlayer == null) {
             event.isCancelled = true
-            plugin.server.scheduler.runTaskAsynchronously(
-                plugin,
-                Runnable {
-                    playerService.save(MfPlayer(plugin, event.player)).onFailure {
-                        event.player.sendMessage("$RED${plugin.language["BlockInteractFailedToSavePlayer"]}")
-                        plugin.logger.log(SEVERE, "Failed to save player: ${it.reason.message}", it.reason.cause)
-                        return@Runnable
+            val playerId = MfPlayerId(event.player.uniqueId.toString())
+            if (playersWithPendingSave.add(playerId)) {
+                plugin.server.scheduler.runTaskAsynchronously(
+                    plugin,
+                    Runnable {
+                        try {
+                            playerService.save(MfPlayer(plugin, event.player)).onFailure {
+                                event.player.sendMessage("$RED${plugin.language["BlockInteractFailedToSavePlayer"]}")
+                                plugin.logger.log(SEVERE, "Failed to save player: ${it.reason.message}", it.reason.cause)
+                                return@Runnable
+                            }
+                        } finally {
+                            playersWithPendingSave.remove(playerId)
+                        }
                     }
-                }
-            )
+                )
+            }
             return
         }
 

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -1175,6 +1175,9 @@ class PlayerInteractListenerTest {
         // another save.
         // Arrange
         `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+        // MfPlayer(plugin, event.player) reads plugin.config.getDouble(...), so config must be mocked
+        // before the scheduled save runnable is actually executed below.
+        setupConfigForDoorInteraction(enabled = false)
         `when`(playerService.save(anyMfPlayer())).thenReturn(Success(mock(MfPlayer::class.java)))
 
         // Act

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -35,6 +35,7 @@ import org.bukkit.scheduler.BukkitScheduler
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.ArgumentMatchers.eq
@@ -1174,7 +1175,7 @@ class PlayerInteractListenerTest {
         // another save.
         // Arrange
         `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
-        `when`(playerService.save(any(MfPlayer::class.java))).thenReturn(Success(mock(MfPlayer::class.java)))
+        `when`(playerService.save(anyMfPlayer())).thenReturn(Success(mock(MfPlayer::class.java)))
 
         // Act
         uut.onPlayerInteract(fixture.event)
@@ -1186,6 +1187,18 @@ class PlayerInteractListenerTest {
     }
 
     // Helper functions
+
+    /**
+     * Mockito's [ArgumentMatchers.any] returns null, which trips Kotlin's null-check on the
+     * non-nullable [MfPlayer] parameter of [MfPlayerService.save] before the matcher is registered,
+     * corrupting Mockito's matcher stack for subsequent tests. This generic indirection avoids the
+     * compiler inserting that check.
+     */
+    private fun <T> anyMfPlayer(): T {
+        ArgumentMatchers.any<MfPlayer>()
+        @Suppress("UNCHECKED_CAST")
+        return null as T
+    }
 
     private inline fun <reified T> mockBlockData() {
         val blockData = mock(T::class.java)

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -16,6 +16,7 @@ import com.dansplugins.factionsystem.player.MfPlayer
 import com.dansplugins.factionsystem.player.MfPlayerId
 import com.dansplugins.factionsystem.player.MfPlayerService
 import com.dansplugins.factionsystem.relationship.MfFactionRelationshipService
+import dev.forkhandles.result4k.Success
 import org.bukkit.Material
 import org.bukkit.Server
 import org.bukkit.World
@@ -1146,6 +1147,42 @@ class PlayerInteractListenerTest {
         verifyEventNotCancelled()
         verifyNoAsyncTaskScheduled()
         verifyPlayerNotNotified()
+    }
+
+    @Test
+    fun onPlayerInteract_PhysicalActionByUnregisteredPlayer_ShouldOnlyScheduleOneSavePerTick() {
+        // Regression test for #1981: applyProtections schedules an async save when the player has no
+        // MfPlayer record. Action.PHYSICAL fires once per tick for as long as the player stands on the
+        // block, so without de-duplication every tick between the first dispatch and the save completing
+        // queues another save. `playerService.getPlayer` returns null by default (unstubbed mock).
+        // Arrange
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+
+        // Act - two physical interactions land before the first save has run
+        uut.onPlayerInteract(fixture.event)
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - both interactions are cancelled, but only one save is in flight
+        verify(fixture.event, org.mockito.Mockito.times(2)).isCancelled = true
+        verify(scheduler, org.mockito.Mockito.times(1)).runTaskAsynchronously(eq(medievalFactions), any(Runnable::class.java))
+    }
+
+    @Test
+    fun onPlayerInteract_PhysicalActionByUnregisteredPlayer_ShouldScheduleAnotherSaveOnceThePriorOneCompletes() {
+        // Once the in-flight save finishes (success or failure), the player is no longer "pending", so a
+        // later physical interaction (e.g. next tick, if the record still isn't visible yet) may dispatch
+        // another save.
+        // Arrange
+        `when`(fixture.event.action).thenReturn(Action.PHYSICAL)
+        `when`(playerService.save(any(MfPlayer::class.java))).thenReturn(Success(mock(MfPlayer::class.java)))
+
+        // Act
+        uut.onPlayerInteract(fixture.event)
+        runScheduledAsyncTasks()
+        uut.onPlayerInteract(fixture.event)
+
+        // Assert - the completed save's player id was released, so the second interaction schedules again
+        verify(scheduler, org.mockito.Mockito.times(2)).runTaskAsynchronously(eq(medievalFactions), any(Runnable::class.java))
     }
 
     // Helper functions


### PR DESCRIPTION
## Summary
- An unregistered player standing on a protected physical block (pressure plate, tripwire, farmland) fires `Action.PHYSICAL` once per tick, and `PlayerInteractListener.applyProtections` previously queued a fresh async `MfPlayer` save for every one of those ticks until the first save completed and populated `MfPlayerService`'s cache.
- Added a per-listener set (`playersWithPendingSave`) tracking player ids with an in-flight save; only the first physical interaction for a given player dispatches a save, and the id is released (success or failure) when that save finishes, so a later interaction can dispatch again if the record still isn't visible.
- `event.isCancelled = true` still runs unconditionally — the protection itself is unchanged, only the redundant scheduling/write is deduped.

## Test plan
- [x] Added `onPlayerInteract_PhysicalActionByUnregisteredPlayer_ShouldOnlyScheduleOneSavePerTick` — two physical interactions before the save runs only schedule one async task.
- [x] Added `onPlayerInteract_PhysicalActionByUnregisteredPlayer_ShouldScheduleAnotherSaveOnceThePriorOneCompletes` — after the first scheduled save runs (success), a subsequent interaction schedules a second save.
- [x] `./gradlew compileKotlin` — passes locally.
- [ ] `./gradlew clean test` — **UNVERIFIED locally**: `compileJava` dies in this sandbox on a pre-existing Gradle user-home compile-cache lock (`Unexpected lock protocol found in lock file. Expected 3, found 0`), unrelated to this change and present before any edits. Relying on the CI `build` check on this PR's head SHA as the verification anchor per this repo's dev-loop UNVERIFIED-anchor rule.

## Data-safety statement
No schema migrations; no DPC contract change; no `config.yml` default change; no `lang/` changes. Purely an in-memory dedup guard around an existing async save path.

Closes #1981

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
