### PR TITLE
Gate wartime block permission checks strictly by Action type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Standing on a *locked* pressure plate (or tripwire, or farmland) you are not allowed to use no longer floods chat with a lock message every tick. This covers the one path missed by the previous physical-interaction fix, and it also stops the per-tick scheduled task and block-owner lookup that each of those messages performed. The lock protection itself is unchanged — the interaction is still blocked.
 - A player with no `MfPlayer` record yet who stands on a protected physical block (pressure plate, tripwire, farmland) no longer queues a duplicate async player-save every tick. Only the first physical interaction dispatches a save; further ticks are ignored until that save completes.
+- Breaking a block in enemy territory (`LEFT_CLICK_BLOCK`) whose material happened to appear in `factions.wartimeInteractableBlocks` was wrongly allowed even when that material was absent from `factions.wartimeBreakableBlocks`, because the interactable-list check ran unconditionally before the action type was considered. Which wartime permission list (breakable / interactable / placeable) applies is now decided strictly by the Bukkit action type and whether the clicked block is interactive, before any wartime list is consulted, so a block appearing in one list can no longer leak permission for a different kind of action.
 
 ## [6.0.0-SNAPSHOT-7-25-2026] – 2026-07-25
 

--- a/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
+++ b/src/main/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListener.kt
@@ -3,6 +3,7 @@ package com.dansplugins.factionsystem.listener
 import com.dansplugins.factionsystem.MedievalFactions
 import com.dansplugins.factionsystem.area.MfBlockPosition
 import com.dansplugins.factionsystem.area.MfCuboidArea
+import com.dansplugins.factionsystem.claim.MfClaimedChunk
 import com.dansplugins.factionsystem.gate.MfGate
 import com.dansplugins.factionsystem.gate.MfGateCreationContext
 import com.dansplugins.factionsystem.interaction.MfInteractionStatus.ADDING_ACCESSOR
@@ -34,7 +35,9 @@ import org.bukkit.block.data.type.TrapDoor
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.event.block.Action.LEFT_CLICK_BLOCK
 import org.bukkit.event.block.Action.PHYSICAL
+import org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.inventory.EquipmentSlot.HAND
 import java.util.concurrent.ConcurrentHashMap
@@ -218,7 +221,7 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
 
         // Allow eating food in faction territory without triggering protection
         val item = event.item
-        if (item != null && item.type.isEdible && !clickedBlock.type.isInteractable) {
+        if (item != null && item.type.isEdible && !isInteractiveBlock(clickedBlock.type)) {
             return
         }
 
@@ -230,9 +233,9 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
                 }
             } else {
                 // Check if player is at war and trying to place a ladder
-                // Only allow if they're right-clicking with a ladder on a solid, non-interactable block
-                val isPlacingLadder = event.action == org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK &&
-                    event.hasItem() && event.item?.type == Material.LADDER && clickedBlock.type.isSolid && !clickedBlock.type.isInteractable
+                // Only allow if they're right-clicking with a ladder on a solid, non-interactive block
+                val isPlacingLadder = event.action == RIGHT_CLICK_BLOCK &&
+                    event.hasItem() && event.item?.type == Material.LADDER && clickedBlock.type.isSolid && !isInteractiveBlock(clickedBlock.type)
                 if (claimService.isWartimeLadderPlacementAllowed(
                         mfPlayer.id,
                         claim,
@@ -242,28 +245,56 @@ class PlayerInteractListener(private val plugin: MedievalFactions) : Listener {
                     // Allow ladder placement in enemy territory during wartime
                     return
                 }
-                if (claimService.isWartimeInteractableBlock(mfPlayer.id, claim, clickedBlock.type)) {
-                    // Block is in the wartime interactable list; allow the interaction
+                if (isWartimeActionAllowed(event, clickedBlock, mfPlayer, claim)) {
                     return
-                }
-                if (event.action == org.bukkit.event.block.Action.LEFT_CLICK_BLOCK &&
-                    claimService.isWartimeBreakableBlock(mfPlayer.id, claim, clickedBlock.type)
-                ) {
-                    // Block is in the wartime breakable list; allow the left-click so BlockBreakEvent can fire
-                    return
-                }
-                if (event.action == org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK && event.hasItem() && !clickedBlock.type.isInteractable) {
-                    val itemType = event.item?.type
-                    if (itemType != null && claimService.isWartimePlaceableBlock(mfPlayer.id, claim, itemType)) {
-                        // Item in hand is in the wartime placeable list; allow the right-click so BlockPlaceEvent can fire
-                        return
-                    }
                 }
                 event.isCancelled = true
                 if (!suppressProtectionMessages) {
                     event.player.sendMessage("$RED${plugin.language["CannotInteractWithBlockInFactionTerritory", claimFaction.name]}")
                 }
             }
+        }
+    }
+
+    /**
+     * Named predicate for "interactive block" (chest, lever, door, etc. - anything that responds
+     * to a right-click independently of what the player is holding). Kept as a thin wrapper around
+     * Bukkit's [Material.isInteractable] - already the definition used elsewhere in this listener
+     * (the edible-food and ladder-placement checks above) - so the definition lives in one named
+     * place per #1970, rather than being re-derived inline at each call site.
+     */
+    private fun isInteractiveBlock(material: Material): Boolean = material.isInteractable
+
+    /**
+     * Strictly gates which wartime permission check (if any) is consulted, based solely on the
+     * Bukkit [org.bukkit.event.block.Action] and whether the clicked block is interactive. The
+     * action type is resolved first and is the sole determinant of which branch runs; the held
+     * item's material plays no role in branch selection (only in the value passed to the placeable
+     * check once that branch is already chosen). This keeps action-type detection and wartime
+     * config evaluation as two separate steps with no overlap - see #1968, #1970.
+     */
+    private fun isWartimeActionAllowed(
+        event: PlayerInteractEvent,
+        clickedBlock: Block,
+        mfPlayer: MfPlayer,
+        claim: MfClaimedChunk
+    ): Boolean {
+        val claimService = plugin.services.claimService
+        return when (event.action) {
+            LEFT_CLICK_BLOCK ->
+                // Block is in the wartime breakable list; allow the left-click so BlockBreakEvent can fire
+                claimService.isWartimeBreakableBlock(mfPlayer.id, claim, clickedBlock.type)
+            RIGHT_CLICK_BLOCK -> if (isInteractiveBlock(clickedBlock.type)) {
+                // Block is in the wartime interactable list; allow the interaction
+                claimService.isWartimeInteractableBlock(mfPlayer.id, claim, clickedBlock.type)
+            } else if (event.hasItem()) {
+                // Item in hand is in the wartime placeable list; allow the right-click so BlockPlaceEvent can fire
+                val itemType = event.item?.type
+                itemType != null && claimService.isWartimePlaceableBlock(mfPlayer.id, claim, itemType)
+            } else {
+                false
+            }
+            else -> false
         }
     }
 

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerInteractListenerTest.kt
@@ -472,7 +472,11 @@ class PlayerInteractListenerTest {
     }
 
     @Test
-    fun onPlayerInteract_WartimeInteractableBlock_ShouldAllowInteraction() {
+    fun onPlayerInteract_WartimeInteractableBlock_HeldItemInPlaceableList_ShouldStillAllowInteractionWithoutConsultingPlaceableList() {
+        // Regression test for #1970 - requirement 4: the item held in hand must play no role in
+        // branch selection. Here the clicked block is interactive AND the held item is itself in
+        // wartimePlaceableBlocks - only the isWartimeInteractableBlock check may run; the
+        // isWartimePlaceableBlock stub for the held item's material must never be reached.
         // Arrange
         setupWartimeLadderTest(
             ladderItem = false,
@@ -482,16 +486,93 @@ class PlayerInteractListenerTest {
         )
 
         val block = fixture.block
+        val event = fixture.event
+        val interactableMaterial = mock(Material::class.java)
+        `when`(interactableMaterial.isSolid).thenReturn(true)
+        `when`(interactableMaterial.isInteractable).thenReturn(true)
+        `when`(block.type).thenReturn(interactableMaterial)
+
         val playerId = MfPlayerId(fixture.player.uniqueId.toString())
         val claim = claimService.getClaim(block.chunk)!!
+        val heldItemMaterial = event.item!!.type
 
-        `when`(claimService.isWartimeInteractableBlock(playerId, claim, block.type)).thenReturn(true)
+        `when`(claimService.isWartimeInteractableBlock(playerId, claim, interactableMaterial)).thenReturn(true)
+        `when`(claimService.isWartimePlaceableBlock(playerId, claim, heldItemMaterial)).thenReturn(true)
 
         // Act
-        uut.onPlayerInteract(fixture.event)
+        uut.onPlayerInteract(event)
 
-        // Assert - event should NOT be cancelled because block is in wartime interactable list
+        // Assert - allowed via the interactable list; the placeable list must never be consulted
         verifyEventNotCancelled()
+        verify(claimService, never()).isWartimePlaceableBlock(playerId, claim, heldItemMaterial)
+    }
+
+    @Test
+    fun onPlayerInteract_LeftClickBlock_NeverConsultsInteractableOrPlaceableLists() {
+        // Regression test for #1970 - requirement 1. Empirically distinguishes old vs. new
+        // behaviour: the old code called isWartimeInteractableBlock(clickedBlock.type) unconditionally,
+        // regardless of action, so a block whose material appeared in wartimeInteractableBlocks would
+        // wrongly be allowed to break even though it is absent from wartimeBreakableBlocks. Under the
+        // fix, LEFT_CLICK_BLOCK must consult only the breakable list.
+        // Arrange
+        setupWartimeLadderTest(
+            ladderItem = false,
+            isWartimeLadderPlacementAllowed = false,
+            configEnabled = false,
+            atWarWithClaimFaction = true
+        )
+
+        val event = fixture.event
+        `when`(event.action).thenReturn(Action.LEFT_CLICK_BLOCK)
+
+        val block = fixture.block
+        val playerId = MfPlayerId(fixture.player.uniqueId.toString())
+        val claim = claimService.getClaim(block.chunk)!!
+        val heldItemMaterial = event.item!!.type
+
+        // Both other lists are wrongly permissive - only the breakable list's answer may matter
+        `when`(claimService.isWartimeBreakableBlock(playerId, claim, block.type)).thenReturn(false)
+        `when`(claimService.isWartimeInteractableBlock(playerId, claim, block.type)).thenReturn(true)
+        `when`(claimService.isWartimePlaceableBlock(playerId, claim, heldItemMaterial)).thenReturn(true)
+
+        // Act
+        uut.onPlayerInteract(event)
+
+        // Assert - blocked: the leaked interactable/placeable stubs must not be reachable from LEFT_CLICK_BLOCK
+        verifyEventCancelled()
+        verify(claimService, never()).isWartimeInteractableBlock(playerId, claim, block.type)
+        verify(claimService, never()).isWartimePlaceableBlock(playerId, claim, heldItemMaterial)
+    }
+
+    @Test
+    fun onPlayerInteract_RightClickPlacingOnNonInteractiveSurface_NeverConsultsInteractableList() {
+        // Regression test for #1970 - requirement 3. The interactable list is wrongly permissive here
+        // (would leak placement rights under the old unconditional isWartimeInteractableBlock call);
+        // the placeable list is the only correct source of truth for a non-interactive surface and
+        // says no, so placement must be blocked.
+        // Arrange
+        setupWartimeLadderTest(
+            ladderItem = false,
+            isWartimeLadderPlacementAllowed = false,
+            configEnabled = false,
+            atWarWithClaimFaction = true
+        )
+
+        val event = fixture.event
+        val block = fixture.block
+        val playerId = MfPlayerId(fixture.player.uniqueId.toString())
+        val claim = claimService.getClaim(block.chunk)!!
+        val heldItemMaterial = event.item!!.type
+
+        `when`(claimService.isWartimeInteractableBlock(playerId, claim, block.type)).thenReturn(true)
+        `when`(claimService.isWartimePlaceableBlock(playerId, claim, heldItemMaterial)).thenReturn(false)
+
+        // Act
+        uut.onPlayerInteract(event)
+
+        // Assert - blocked (placeable list says no), and the interactable list is never touched
+        verifyEventCancelled()
+        verify(claimService, never()).isWartimeInteractableBlock(playerId, claim, block.type)
     }
 
     @Test
@@ -806,9 +887,12 @@ class PlayerInteractListenerTest {
         // Act
         uut.onPlayerInteract(event)
 
-        // Assert — interaction must be blocked; placeable list must not affect interactive blocks
+        // Assert — interaction must be blocked; placeable list must not affect interactive blocks.
+        // Regression test for #1970 - requirement 2: the placeable check must never be reached for
+        // an interactive block, not merely produce the right outcome.
         verifyEventCancelled()
         verifyPlayerNotified()
+        verify(claimService, never()).isWartimePlaceableBlock(playerId, claim, itemMaterial)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Refactors `PlayerInteractListener`'s wartime block-permission handling so which check runs (`isWartimeBreakableBlock` / `isWartimeInteractableBlock` / `isWartimePlaceableBlock`) is decided **strictly** by the Bukkit `Action` and whether the clicked block is interactive, resolved *before* any wartime config is consulted — the two concerns (action-type detection and wartime evaluation) no longer overlap.
- Fixes the residual bug this created room for: `isWartimeInteractableBlock` was previously called unconditionally, regardless of action, so a block whose material happened to appear in `wartimeInteractableBlocks` could be **broken** (`LEFT_CLICK_BLOCK`) even though it wasn't in `wartimeBreakableBlocks`. `#1968` (holding a placeable item unlocking interaction) was already fixed by an earlier ad-hoc guard; this closes the remaining gap and replaces the ad-hoc guard with an explicit, testable structure so it can't regress the same way again.
- Introduces a single named `isInteractiveBlock(material)` predicate (currently a thin wrapper over `Material.isInteractable`, which was already the definition used elsewhere in this same listener) so "what counts as interactive" lives in one place.
- Adds/strengthens regression tests per the issue's spec, including `verify(..., never())` assertions that the *wrong* list is never consulted, not just that the outcome happens to be correct.

## Test plan
- [x] `./gradlew clean test` — full suite green (`PlayerInteractListenerTest`: 42 tests, all passing)
- [x] `./gradlew lintKotlin` — clean
- [x] **Empirical regression check** (stash-and-run): reverted only the production file and re-ran `PlayerInteractListenerTest` — exactly the two tests written to reproduce the LEFT_CLICK_BLOCK leak (`onPlayerInteract_LeftClickBlock_NeverConsultsInteractableOrPlaceableLists`, `onPlayerInteract_RightClickPlacingOnNonInteractiveSurface_NeverConsultsInteractableList`) failed with `WantedButNotInvoked`; all other tests still passed. Confirms these two are genuine FAIL(before)→PASS(after) regression tests, not just characterization.
- [x] All 4 of the issue's required regression-test scenarios are covered (LEFT_CLICK_BLOCK isolation, RIGHT_CLICK interactive isolation, RIGHT_CLICK placement isolation, held-item-doesn't-influence-branch), plus the CHANGELOG `[Unreleased]` entry.

## Data-safety statement
No schema migrations, no DPC contract change, no `config.yml` default change, no `plugin.yml` change. Pure in-memory permission-gating logic in a single listener; the semantics of `wartimePlaceableBlocks`/`wartimeBreakableBlocks`/`wartimeInteractableBlocks` config and the three `MfClaimService` methods are unchanged, per the issue's own "What This Does Not Change" section.

Closes #1970

<!-- gardener-tend-dispatch -->


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
