### PR TITLE
docs: document the mf.force.* permission overrides in COMMANDS.md

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -123,7 +123,7 @@ The main faction command can be accessed using any of the following aliases:
 
 **Example:** `/f flag set color #FF0000`
 
-**Notes:** With `mf.force.flag` (default: op), a faction name or ID can be given as the first argument to list or set flags on a faction other than your own (`/f flag list FactionName [page]`, `/f flag set FactionName [flag] [value]`). Unlike `mf.force.kick` and `mf.force.rename`, this genuinely bypasses the target faction's role permissions; setting a flag this way still additionally requires `mf.flag.set`. The permission also enables faction-name tab completion for both subcommands.
+**Notes:** With `mf.force.flag` (default: op), a faction name or ID can be given as the first argument to list or set flags on a faction other than your own (`/f flag list FactionName [page]`, `/f flag set FactionName [flag] [value]`). Unlike `mf.force.kick` and `mf.force.rename`, this genuinely bypasses the target faction's role permissions; the base `mf.flag.list` / `mf.flag.set` node is still required. The permission also enables faction-name tab completion for both subcommands.
 
 See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 
@@ -365,7 +365,7 @@ See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 - `/unlock` - Enables unlock mode
 - `/unlock cancel` - Cancels unlock mode
 
-**Notes:** Normally you can only unlock blocks you locked yourself. With `mf.force.unlock` (default: op), unlock mode also works on blocks locked by another player, and breaking another player's locked block unlocks it instead of being refused. A message is shown naming the lock owner whose protection was bypassed. (Faction roles can also grant a lock bypass independently of this permission.)
+**Notes:** Normally you can only unlock blocks you locked yourself. With `mf.force.unlock` (default: op), unlock mode also works on blocks locked by another player — a message naming the lock owner whose protection was bypassed is shown — and breaking another player's locked block unlocks it instead of being refused. (A faction role can also grant a lock bypass for unlock mode, independently of this permission.)
 
 ### `/accessors list`
 **Permission:** `mf.accessors.list` (default: true)  

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -17,7 +17,10 @@ This document provides a comprehensive list of all commands available in the Med
 - [Power System](#power-system)
 - [Chat System](#chat-system)
 - [Applications](#applications)
+- [Moderator Approval](#moderator-approval)
 - [Admin Commands](#admin-commands)
+- [DPC Community API](#dpc-community-api)
+- [Permission Groups](#permission-groups)
 
 ## Command Aliases
 
@@ -75,7 +78,8 @@ The main faction command can be accessed using any of the following aliases:
 ### `/faction join [faction]` or `/f join [faction]`
 **Permission:** `mf.join` (default: true)  
 **Description:** Joins a faction that you have been invited to.  
-**Usage:** `/f join FactionName`
+**Usage:** `/f join FactionName`  
+**Notes:** With `mf.force.join` (default: op), you can join a faction you were never invited to. Running `/f join FactionName` without an invite shows a clickable confirmation prompt instead of the "not invited" error; appending `-f` (`/f join FactionName -f`) skips the prompt and joins immediately.
 
 ### `/faction leave` or `/f leave`
 **Permission:** `mf.leave` (default: true)  
@@ -90,7 +94,8 @@ The main faction command can be accessed using any of the following aliases:
 ### `/faction kick [player]` or `/f kick [player]`
 **Permission:** `mf.kick` (default: true)  
 **Description:** Kicks a player from your faction.  
-**Usage:** `/f kick PlayerName`
+**Usage:** `/f kick PlayerName`  
+**Notes:** With `mf.force.kick` (default: op), a faction name can be given before the player (`/f kick FactionName PlayerName`) to target a faction other than the one you are in. The faction-role check is still applied against the target faction, so you must also hold that faction's kick role permission — the permission selects which faction is acted on, it does not by itself override the faction's own permissions.
 
 ### `/faction set [name|description|prefix] [value]` or `/f set [name|description|prefix] [value]`
 **Permissions:** 
@@ -104,6 +109,8 @@ The main faction command can be accessed using any of the following aliases:
 - `/f set description "Our faction description"` - Sets faction description
 - `/f set prefix [TAG]` - Sets faction prefix
 
+**Notes:** With `mf.force.rename` (default: op), a faction name or ID can be given before the new name (`/f set name FactionName NewName`) to rename a faction other than the one you are in. As with `mf.force.kick`, the faction-role check still runs against the target faction, so you must also hold that faction's change-name role permission.
+
 ### `/faction flag [list|set]` or `/f flag [list|set]`
 **Permissions:** 
 - `mf.flag.list` (default: true)
@@ -115,6 +122,8 @@ The main faction command can be accessed using any of the following aliases:
 - `/f flag set [flag] [value]` - Sets a flag value
 
 **Example:** `/f flag set color #FF0000`
+
+**Notes:** With `mf.force.flag` (default: op), a faction name or ID can be given as the first argument to list or set flags on a faction other than your own (`/f flag list FactionName [page]`, `/f flag set FactionName [flag] [value]`). Unlike `mf.force.kick` and `mf.force.rename`, this genuinely bypasses the target faction's role permissions; setting a flag this way still additionally requires `mf.flag.set`. The permission also enables faction-name tab completion for both subcommands.
 
 See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 
@@ -356,6 +365,8 @@ See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 - `/unlock` - Enables unlock mode
 - `/unlock cancel` - Cancels unlock mode
 
+**Notes:** Normally you can only unlock blocks you locked yourself. With `mf.force.unlock` (default: op), unlock mode also works on blocks locked by another player, and breaking another player's locked block unlocks it instead of being refused. A message is shown naming the lock owner whose protection was bypassed. (Faction roles can also grant a lock bypass independently of this permission.)
+
 ### `/accessors list`
 **Permission:** `mf.accessors.list` (default: true)  
 **Aliases:** `/accessoren list`, `/accesseurs list`  
@@ -486,7 +497,7 @@ See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 **Usage:** `/f admin setleader FactionName PlayerName`
 
 ### `/faction addmember [faction] [player]` or `/f addmember [faction] [player]`
-**Permission:** `mf.force.addmember` (default: op)  
+**Permission:** `mf.force.addmember` or `mf.force.join` (default: op)  
 **Description:** Forcefully adds a player to a faction (admin command).  
 **Usage:** `/f addmember FactionName PlayerName`
 
@@ -544,6 +555,24 @@ The `mf.admin` permission grants access to all admin commands including:
 - `mf.admin.setleader` - Set faction leaders
 - `mf.approve` - Approve/deny pending faction actions
 - `mf.dpc` - Manage DPC community API settings
+
+### Force Permissions
+The `mf.force.*` nodes (all `default: op`) do not add new commands — each one changes the behavior of an existing command or listener. They are documented with the command they affect; this table is an index.
+
+| Permission | Affects | Effect |
+|------------|---------|--------|
+| `mf.force.addmember` | [`/f addmember`](#faction-addmember-faction-player-or-f-addmember-faction-player) | Forcefully adds a player to a faction. |
+| `mf.force.bonuspower` | [`/f bonuspower`](#faction-bonuspower-faction-amount-or-f-bonuspower-faction-amount) | Sets a faction's bonus power. |
+| `mf.force.flag` | [`/f flag list`, `/f flag set`](#faction-flag-listset-or-f-flag-listset) | Lists/sets flags on another faction, bypassing its role permissions. |
+| `mf.force.join` | [`/f join`](#faction-join-faction-or-f-join-faction), [`/f addmember`](#faction-addmember-faction-player-or-f-addmember-faction-player) | Joins a faction without an invite (confirmation prompt, or `-f` to skip it). Also grants `/f addmember`. |
+| `mf.force.kick` | [`/f kick`](#faction-kick-player-or-f-kick-player) | Targets a faction other than your own; the target faction's role check still applies. |
+| `mf.force.power` | [`/power set`](#power-set-player-amount) | Sets a player's power (alternative to `mf.power.set`). |
+| `mf.force.rename` | [`/f set name`](#faction-set-namedescriptionprefix-value-or-f-set-namedescriptionprefix-value) | Targets a faction other than your own; the target faction's role check still applies. |
+| `mf.force.unlock` | [`/unlock`](#unlock-cancel), block breaking | Unlocks blocks locked by another player. |
+
+`mf.force.claim` and `mf.force.unclaim` are declared in `plugin.yml` and granted by `mf.force.*`, but nothing in the plugin currently reads them — granting them has no effect. See issue [#1987](https://github.com/Dans-Plugins/Medieval-Factions/issues/1987).
+
+`mf.force.kick` and `mf.force.rename` only widen which faction the command targets; the target faction's own role check still applies. `mf.force.flag` behaves differently and does bypass it. See issue [#1988](https://github.com/Dans-Plugins/Medieval-Factions/issues/1988).
 
 ## Notes
 


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

Documentation-only. `COMMANDS.md` never mentioned five of the ten `mf.force.*` permission nodes, even though each one changes the behaviour of a command an admin is likely to reach for. Every note below was written by reading the command/listener source, not the `plugin.yml` description.

- **`mf.force.join`** → `/f join` — join a faction you were never invited to. Without `-f` this shows a clickable confirmation prompt instead of the "not invited" error; `/f join FactionName -f` skips the prompt.
- **`mf.force.kick`** → `/f kick` — the two-argument `/f kick FactionName PlayerName` form that targets a faction other than your own.
- **`mf.force.rename`** → `/f set name` — the `/f set name FactionName NewName` form.
- **`mf.force.flag`** → `/f flag list|set` — a faction name/ID as the first argument, plus faction-name tab completion.
- **`mf.force.unlock`** → `/unlock` and block breaking — unlocking a block locked by *another player*.

Also in this PR:

- A **Force Permissions** index table under `Permission Groups`, since these nodes add no commands of their own and are therefore hard to find. It records that `mf.force.claim` / `mf.force.unclaim` are declared in `plugin.yml` but read nowhere in the source.
- `/f addmember`'s permission line corrected to `mf.force.addmember` **or** `mf.force.join` — `MfFactionAddMemberCommand.kt:21` accepts either.
- Three `##` sections that were missing from the table of contents (`Moderator Approval`, `DPC Community API`, `Permission Groups`), and the two `mf.approve` / `mf.dpc` bullets kept with the Admin Permissions list they belong to.

## Two findings filed rather than fixed

A documentation cycle should not silently change behaviour, so both of these are documented as they currently are and tracked separately:

- **#1987** — `mf.force.claim` and `mf.force.unclaim` are declared and granted by `mf.force.*` but never read anywhere in `src/main/kotlin`. Needs a maintainer call: implement the feature, or delete the dead declarations.
- **#1988** — `mf.force.kick` and `mf.force.rename` only widen *which faction* the command targets; the target faction's role check still runs against the sender afterwards, so an admin who is not a member of that faction is still refused. `mf.force.flag` genuinely bypasses the role check. The two behaviours disagree, and `plugin.yml`'s descriptions match the flag one. Fixing it would widen an op-default permission, so it wants a deliberate decision.

The `COMMANDS.md` notes describe today's actual behaviour, caveat included, and both notes point at the tracking issue so they get updated when a decision lands.

## Test plan

- [x] Every claim verified against source: `MfFactionJoinCommand.kt`, `MfFactionKickCommand.kt`, `MfFactionSetNameCommand.kt`, `MfFactionFlagListCommand.kt`, `MfFactionFlagSetCommand.kt`, `MfFactionAddMemberCommand.kt`, `PlayerInteractListener.kt`, `BlockBreakListener.kt`, `plugin.yml`.
- [x] Anchor links in the new table checked against the actual `###` headings in `COMMANDS.md`.
- [ ] CI `build` / `docker-build` green.

**Local build anchor:** UNVERIFIED-not-applicable. No Kotlin, resource, or build file is touched, so `./gradlew test` has nothing to say about this diff; CI on the head SHA is the anchor.

**No `CHANGELOG.md` entry:** no plugin behaviour changed. This follows the precedent of the previous docs-only commit on `main` (`aabad183`, PR #1985), which also added none.

## Data-safety statement

No schema migrations; no DPC contract change; no `config.yml` default change; no `plugin.yml` change; no lang-file change. Single-file documentation diff (`COMMANDS.md`, +32/-3).

## Deferred backlog

This cycle was scoped to #1986; the rest of the open issue backlog and the four remaining open PRs (#1915, #1918, #1944, #1948 — all currently conflicting with `main`) were not touched. #1919 was already groomed and self-reviewed in a previous cycle and is awaiting human approval.

Closes #1986


---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
