### PR TITLE
Document mf.claim.circle permission and circle claim alias

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -130,15 +130,17 @@ See [FACTION_FLAGS.md](FACTION_FLAGS.md) for a complete list of available flags.
 ## Territory & Claims
 
 ### `/faction claim [radius]` or `/f claim [radius]`
-**Permission:** `mf.claim` (default: true)  
-**Description:** Claims the chunk you are standing in, or claims in a radius if specified.  
+**Permission:** `mf.claim` or `mf.claim.circle` (default: true)  
+**Description:** Claims the chunk you are standing in, or claims in a circular radius if specified.  
 **Usage:**
 - `/f claim` - Claims the current chunk
-- `/f claim 2` - Claims chunks in a 2-chunk radius (5x5 area)
+- `/f claim 2` - Claims chunks in a circular 2-chunk radius
+- `/f claim circle 2` - Same as above; `circle` is an explicit alias for the default radius-claiming behavior
 
 **Notes:** 
 - Each chunk claimed requires power. Your faction must have enough power to claim land.
 - Maximum claim radius is configurable (default: 3).
+- The claimed area is a circle (chunks within the given radius of your current chunk), not a square.
 
 ### `/faction claim auto` or `/f claim auto`
 **Permission:** `mf.claim.auto` or `mf.autoclaim` (default: true)  


### PR DESCRIPTION
## Summary
- `COMMANDS.md`'s `/f claim [radius]` entry only mentioned the `mf.claim` permission, but `MfFactionClaimCircleCommand` also accepts `mf.claim.circle` (either is sufficient) — this node was declared in `plugin.yml` but undocumented.
- Documents the `circle` subcommand alias (`/f claim circle [radius]`), which routes to the same circle-claiming logic that the bare `/f claim [radius]` form falls back to by default.
- Clarifies that the claimed area is a circle (Euclidean distance check in `MfFactionClaimCircleCommand`), not a square, which the prior wording left ambiguous.

Found during this cycle's documentation accuracy sweep (Phase 2 Stage A): cross-checked every `mf.*` permission node in `plugin.yml` against `COMMANDS.md` — `mf.claim.circle` was the only one missing a mention. `CONFIG.md` and `FACTION_FLAGS.md` were also swept and found fully in sync with `config.yml`/`MfFlags.kt` (no changes needed there).

## Test plan
- [x] Docs-only change — no source touched, no test-affecting behavior. Verified against `MfFactionClaimCommand.kt` / `MfFactionClaimCircleCommand.kt` / `plugin.yml` directly.
- [x] `git diff` reviewed — single file, additive wording only.

## Data safety
No schema migrations; no DPC contract change; no config-default change. Docs-only, no `.github/workflows/*` change.

Backlog note: the rest of the open-issue backlog was reviewed but deferred this cycle — every remaining open PR (#1944, #1918, #1915, #1948) is human-gated (large/conflicting/data-safety-sensitive, previously documented in PR comments across earlier grooming cycles) and the open bug issues found (#1987, #1988) are explicitly maintainer-design-decision-gated per their own issue bodies, not mechanical fixes.

---

_drafted by Claude on behalf of Daniel Stephenson_