### PR TITLE
docs: add FAQ.md documenting forceful faction disband, and skip CI builds for docs-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,19 +9,77 @@ permissions:
   contents: read
 
 jobs:
+  # Decides whether a pull request touches anything buildable. The build and
+  # docker-build jobs below still run and still report a status either way,
+  # because both are required status checks on main and a check that never
+  # reports leaves a pull request blocked forever. What changes is that their
+  # expensive steps are skipped for documentation-only changes.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.filter.outputs.docs_only }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether only documentation changed
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Anything other than a pull request always gets a full build.
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA"); then
+            # If the diff cannot be resolved, build rather than guess.
+            echo "Could not diff $BASE_SHA..$HEAD_SHA, assuming a full build is needed"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "$changed"
+
+          # A change counts as documentation only if every changed file is a
+          # markdown file or the licence. Everything else - sources, resources,
+          # gradle files, Dockerfile, workflows - forces a full build.
+          if echo "$changed" | grep -qvE '(\.md$|^LICENSE$)'; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Report decision
+        run: echo "docs_only=${{ steps.filter.outputs.docs_only }}"
+
   build:
     runs-on: ubuntu-latest
+    needs: changes
+    # Runs even if the filter job fails, so the required check always reports.
+    if: always()
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Skip build for documentation-only changes
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Only documentation changed - nothing to build."
+
       - name: Set up JDK 17
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Build Ponder dependency
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           git clone https://github.com/Dans-Plugins/Ponder.git /tmp/Ponder
           cd /tmp/Ponder
@@ -30,16 +88,26 @@ jobs:
           ./gradlew publishToMavenLocal
 
       - name: Grant execute permission for gradlew
+        if: needs.changes.outputs.docs_only != 'true'
         run: chmod +x gradlew
 
       - name: Build with Gradle
+        if: needs.changes.outputs.docs_only != 'true'
         run: ./gradlew clean build
 
   docker-build:
     runs-on: ubuntu-latest
+    needs: changes
+    # Runs even if the filter job fails, so the required check always reports.
+    if: always()
 
     steps:
       - uses: actions/checkout@v4
 
+      - name: Skip image build for documentation-only changes
+        if: needs.changes.outputs.docs_only == 'true'
+        run: echo "Only documentation changed - nothing to build."
+
       - name: Build Docker image
+        if: needs.changes.outputs.docs_only != 'true'
         run: docker build -t medieval-factions:ci-test .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- `FAQ.md`, a committed FAQ document alongside the existing guides. The first section covers disbanding: how self-disband works, and that `/faction disband <faction name>` (permission `mf.disband.others`, default `op`) force-disbands any faction, bypassing both the `DISBAND` role permission check and the last-member-only requirement, with no confirmation prompt. Linked from `README.md` and `USER_GUIDE.md`.
+
 ### Changed
 - `/faction addmember` no longer silently refuses when the target player is already in another faction. It now prompts the admin for confirmation before removing the player from their current faction and adding them to the target; the `-f` flag skips the prompt and moves the player immediately. Both factions are notified of the move.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,5 +74,8 @@ docker compose up
 
 This will start a Spigot server on your local machine. You can connect to it using the IP `localhost` and the port `25565`.
 
+### Continuous Integration
+Every pull request runs the `build` and `docker-build` checks. If a pull request changes nothing but markdown files, both checks still report, but the Gradle build and the Docker image build are skipped, so documentation changes are not held up by a full build. Any change outside markdown — sources, resources, gradle files, the `Dockerfile`, workflows — triggers the full build as usual.
+
 ## Questions
 If you have any questions about contributing to the project, feel free to ask in the Discord server. You can join the Discord server [here](https://discord.gg/xXtuAQ2). This is the best place to ask questions.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,80 @@
+# Medieval Factions - FAQ
+
+Answers to questions that come up often. For a full command list see [COMMANDS.md](COMMANDS.md), and for
+step-by-step walkthroughs see the [User Guide](USER_GUIDE.md).
+
+## Table of Contents
+- [Disbanding Factions](#disbanding-factions)
+  - [How do I disband my own faction?](#how-do-i-disband-my-own-faction)
+  - [Is there a way to forcefully disband a faction?](#is-there-a-way-to-forcefully-disband-a-faction)
+  - [Why does `/f disband` tell me the faction must be empty?](#why-does-f-disband-tell-me-the-faction-must-be-empty)
+  - [Can I disband a faction from the console or a command block?](#can-i-disband-a-faction-from-the-console-or-a-command-block)
+  - [What happens to claims and gates when a faction is disbanded?](#what-happens-to-claims-and-gates-when-a-faction-is-disbanded)
+  - [Can a disband be undone?](#can-a-disband-be-undone)
+
+## Disbanding Factions
+
+### How do I disband my own faction?
+
+Run `/f disband` with no arguments. Two conditions must be met:
+
+1. Your role in the faction must have the `DISBAND` faction permission. Of the three default roles
+   (Member, Officer, Owner), only **Owner** is granted it out of the box.
+2. You must be the **only remaining member** of the faction. Everyone else has to leave or be kicked first.
+
+You also need the `mf.disband` server permission, which is `default: true`.
+
+### Is there a way to forcefully disband a faction?
+
+Yes. Passing a faction name as an argument — `/f disband <faction name>` — force-disbands that faction and
+**skips both of the checks above**: no `DISBAND` role permission is required, and the faction is deleted
+regardless of how many members it has.
+
+This form requires the `mf.disband.others` server permission, which is `default: op`. Grant it deliberately;
+anyone who holds it can delete any faction on the server.
+
+```
+/f disband Kingdom of Example
+```
+
+Notes:
+
+- Faction names with spaces work without quoting — everything after `disband` is treated as the name.
+- The lookup is by exact faction name. Tab-completion offers matching faction names.
+- The `mf.disband` permission is checked first, so revoking `mf.disband` from a player also blocks the
+  forceful form for them.
+- There is **no confirmation prompt**. The faction is deleted as soon as the command runs.
+
+### Why does `/f disband` tell me the faction must be empty?
+
+The self-disband path deliberately requires you to be the last member, so a faction cannot be deleted out
+from under players who are still in it. Kick or wait for the remaining members to leave, or ask an
+administrator to use the forceful form described above.
+
+### Can I disband a faction from the console or a command block?
+
+No. `/f disband` rejects any non-player sender, including the server console and command blocks. Forceful
+disbands have to be run in-game by a player who holds `mf.disband.others`.
+
+### What happens to claims and gates when a faction is disbanded?
+
+Disbanding cascades: all of the faction's claimed chunks are released and all of its gates are deleted
+along with the faction record. If Dynmap integration is enabled, the map is refreshed to drop the removed
+territory (unless `dynmap.onlyRenderTerritoriesUponStartup` is set).
+
+### Can a disband be undone?
+
+No. There is no built-in undo or restore for a disbanded faction — the deletion is permanent once it
+succeeds. Take a database backup before running forceful disbands on a live server.
+
+For plugin developers: disbanding fires a cancellable `FactionDisbandEvent` before anything is deleted, so
+an add-on can veto a disband (including a forceful one) if a server needs stricter rules.
+
+---
+
+## Additional Resources
+
+- [Commands Reference](COMMANDS.md) - Complete list of all commands
+- [User Guide](USER_GUIDE.md) - Getting started and common scenarios
+- [Configuration Guide](CONFIG.md) - Server configuration options
+- [Wiki FAQ](https://github.com/Dans-Plugins/Medieval-Factions/wiki/FAQ) - Community-maintained questions

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dynmap has been integrated with this plugin. In order to be able to view claimed
 
 ### Documentation
 - [User Guide](USER_GUIDE.md) - Getting started and common scenarios
+- [FAQ](FAQ.md) - Answers to frequently asked questions
 - [Commands Reference](COMMANDS.md) - Complete list of all commands
 - [Configuration Guide](CONFIG.md) - Detailed config options
 - [Faction Flags](FACTION_FLAGS.md) - Faction flag reference

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -957,6 +957,7 @@ Duels are time-limited and notify nearby players.
 ## Additional Resources
 
 - [Commands Reference](COMMANDS.md) - Complete list of all commands
+- [FAQ](FAQ.md) - Answers to frequently asked questions
 - [Configuration Guide](CONFIG.md) - Server configuration options
 - [Faction Flags](FACTION_FLAGS.md) - Detailed flag documentation
 - [GitHub Repository](https://github.com/Dans-Plugins/Medieval-Factions) - Source code and issues


### PR DESCRIPTION
## Summary

Two changes: a new committed FAQ, and a CI gate so documentation-only pull requests like this one are not held up by a full build.

## 1. `FAQ.md`

The repository had no committed FAQ — the only FAQ was on the wiki. This adds `FAQ.md` alongside the existing guides, opening with a section on disbanding factions.

The question that prompted it: **is there a way to forcefully disband a faction?** There is. `/faction disband <faction name>` requires the `mf.disband.others` permission (`default: op`) and skips *both* checks the self-disband path enforces — the `DISBAND` faction-role permission and the "you must be the only member" requirement. `COMMANDS.md` mentions this in a trailing note on the `/f disband` entry; the FAQ makes it findable by the question people actually ask.

What the FAQ covers:

- How self-disband works (Owner role holds `DISBAND` by default; must be the last member)
- The forceful form, its permission, and that it has no confirmation prompt
- Why the empty-faction check exists
- That the command rejects non-player senders, so it cannot be run from console or a command block
- That disbanding cascades to claims and gates, and refreshes Dynmap
- That there is no undo, plus the note for developers that `FactionDisbandEvent` is cancellable

Every answer was checked against `MfFactionDisbandCommand`, `MfFactionService.delete`, `MfFactionRoles.defaults` and `plugin.yml` at the base commit.

`FAQ.md` is linked from the documentation lists in `README.md` and `USER_GUIDE.md`, with a `CHANGELOG.md` entry under Unreleased.

## 2. Docs-only pull requests skip the build

`build` and `docker-build` are both required status checks on `main`, so `paths-ignore` is not usable here — a workflow filtered out by paths never reports, and the required check stays pending, blocking the pull request indefinitely.

Instead, a `changes` job diffs the pull request against its base and sets a `docs_only` output when every changed file is markdown or `LICENSE`. Both jobs still run and still report their status, but their expensive steps — the Ponder clone, the Gradle build, the Docker image build — are skipped when `docs_only` is set. Job names are unchanged, so branch protection needs no reconfiguration.

The gate fails toward building. Non-pull-request events, an unresolvable diff, and a failed `changes` job all leave `docs_only` unset, which runs the full build. Anything outside markdown — sources, resources, gradle files, the `Dockerfile`, the workflows themselves — counts as a code change.

Documented under a new Continuous Integration heading in `CONTRIBUTING.md`.

## Verification

No plugin code changes, so there is nothing to build or test in the plugin itself. The workflow was checked for valid YAML and the changed-file classifier was exercised against representative paths (markdown only, markdown plus a Kotlin source, `LICENSE`, `Dockerfile`, a nested `.md`, a workflow file, a lang `.properties`), each landing on the expected side.

Because this pull request edits `.github/workflows/build.yml`, it is not itself docs-only — its own CI run exercises the full build path, which is the one worth confirming before merge. Subsequent markdown-only pull requests will take the skip path.

---
drafted by Claude on behalf of Daniel Stephenson