### PR TITLE
docs: point CONTRIBUTING.md at main rather than the retired develop branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,15 @@ Work items are organized into milestones, which represent a specific version of 
 
 ## Making Changes
 - Before you start working on something, make sure there is an issue for it. If there isn't, create one.
-- Make sure you are working on the "develop" branch. If you are not, switch to it using `git checkout develop`.
+- Make sure you are working on the "main" branch. If you are not, switch to it using `git checkout main`.
 - Create a new branch for your changes using `git checkout -b <branch-name>`. Make sure to name your branch something that is related to the issue you are working on.
 - Make your changes to the code.
 - Test your changes to make sure they work as expected. [More information on testing can be found here](#testing).
 - When you are finished, commit your changes using `git commit -m "Your commit message here"`.
 - Push your changes to your fork using `git push origin <branch-name>`.
-- Open a pull request on the original repository. Make sure to include a description of your changes and link the related issue using #(number). The develop branch should be used as the base branch.
+- Open a pull request on the original repository. Make sure to include a description of your changes and link the related issue using #(number). The main branch should be used as the base branch.
 - Wait for your pull request to be reviewed. If there are any changes that need to be made, make them and push the changes to your fork. Your pull request will be updated automatically.
-- Once your pull request has been reviewed and approved, it will be merged into the develop branch.
+- Once your pull request has been reviewed and approved, it will be merged into the main branch.
 
 ### Language Files
 The plugin supports multiple languages. Code changes that require changes to the language files should include the changes to the language files as well. If you are adding a new language, you will need to create a new language file. The language files are located in the `src/main/resources/lang` directory.


### PR DESCRIPTION
## Problem

Contributors are instructed by `CONTRIBUTING.md` to work on and target a `develop` branch:

> Make sure you are working on the "develop" branch. If you are not, switch to it using `git checkout develop`.

That branch no longer exists on the remote — `git ls-remote --heads origin develop` returns nothing — so the instruction fails outright for anyone following the guide, at the very first step of making a change. The base-branch instruction further down sends any pull request that does get opened at a branch that cannot be selected.

## Why main is correct

Trunk-based development on `main` is already the established flow, and is already documented in `.github/copilot-instructions.md`:

> Branch from `main` for all changes. (The legacy `develop` branch was retired; trunk-based development on `main` is the current flow.)

It is also what practice shows: of the last 30 merged pull requests, 27 targeted `main`, and the 3 that targeted `develop` predate its retirement.

## Change

The three stale references in `CONTRIBUTING.md` are updated to name `main`. No other guidance is altered, and no code is touched.

This was noticed while three unrelated issues were being worked on, each of which had to be told explicitly to disregard the guide and target `main`.

Closes #2004

---

*Investigated and drafted by Claude on behalf of Daniel Stephenson.*
