### PR TITLE
ci: retry dev prerelease publishing and assert a single JAR

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -58,18 +58,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
+
+          # Dan's Plugin Manager installs the first .jar asset it finds on the release, so publishing
+          # more than one would leave the installed build depending on asset order. An empty or
+          # ambiguous match fails the run rather than publishing something unpredictable.
+          jars=(build/libs/*-all.jar)
+          if [ ${#jars[@]} -ne 1 ]; then
+            echo "Expected exactly one JAR to publish, found ${#jars[@]}: ${jars[*]:-none}" >&2
+            exit 1
+          fi
 
           # The dev tag has to move to the new commit. Editing a published release does not move its
-          # tag, so the release and its tag are deleted and recreated. This leaves a window of a few
-          # seconds with no dev release; a client that fetches during it sees "no experimental build
-          # published" and succeeds on the next attempt.
-          gh release delete dev --yes --cleanup-tag || true
+          # tag, so the release and its tag are deleted and recreated. That leaves a window with no
+          # dev release, and a transient API failure inside it would strand the repository there
+          # until someone noticed by hand — which has happened. Each attempt therefore starts from a
+          # clean slate, so a half-finished attempt cannot wedge the next one.
+          published=
+          for attempt in 1 2 3; do
+            if [ -n "${attempt_delay:-}" ]; then sleep "$attempt_delay"; fi
+            attempt_delay=$((attempt * 15))
 
-          gh release create dev \
-            --prerelease \
-            --target "$GITHUB_SHA" \
-            --title "Development build" \
-            --notes "Automated build of \`main\` at ${GITHUB_SHA}.
+            gh release delete dev --yes --cleanup-tag || true
+
+            if gh release create dev \
+              --prerelease \
+              --target "$GITHUB_SHA" \
+              --title "Development build" \
+              --notes "Automated build of \`main\` at ${GITHUB_SHA}.
 
           **This is not a release.** It is unreleased, unreviewed code that has not been through any
           release check, and a broken build can stop a server from starting. Do not run it on a server
@@ -82,4 +98,15 @@ jobs:
           \`\`\`
 
           Return to published releases with \`/dpm get medievalfactions --stable\`." \
-            build/libs/*-all.jar
+              "${jars[0]}"; then
+              published=1
+              break
+            fi
+
+            echo "Publishing the dev prerelease failed (attempt $attempt of 3)." >&2
+          done
+
+          if [ -z "$published" ]; then
+            echo "Could not publish the dev prerelease after 3 attempts. The dev release may be missing until this workflow is re-run." >&2
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The `Dev Release` workflow now retries publishing the `dev` prerelease before giving up, and asserts that exactly one JAR is being published. The release and its tag have to be deleted and recreated for the tag to move to the new commit, and a transient API failure inside that window previously left the repository with no `dev` release at all until the workflow was re-run by hand.
+
 ### Added
 - A JSON file storage backend as an alternative to the database, selected with `storage.type: json` in `config.yml`. The default remains `database`, so existing servers are unaffected. Files are written to `storage.json.path`, one per entity type. `players.json` and `factions.json` are validated against a JSON schema before being written; the other entity files are not yet schema-validated, and no file is validated when read back. Intended for smaller servers that want simpler deployment and file-level backups — the database backend remains the better choice under load, since every JSON write rewrites the whole file for that entity type.
 - `/faction migrate toJson` and `/faction migrate toDatabase` (permission `mf.migrate`, default `op`), which copy all data between the two storage backends. The migration runs asynchronously; `storage.type` must be changed and the server restarted afterwards for the new backend to take effect. The target backend must be empty — the command refuses to migrate into one that already holds data — and it should be run with no players online, since changes made while it runs may not be carried over. When migrating to JSON, only the most recent 1000 chat messages per faction are retained. See `docs/MIGRATION_GUIDE.md`.


### PR DESCRIPTION
This repository was the pilot for the `Dev Release` workflow, so it predates two safeguards that the other 25 repositories in the rollout received. This brings it into line.

## Retry on publish

For DPM to see a new experimental build, the `dev` tag has to move to the new commit — which requires the release to be deleted and recreated, since editing a published release does not move its tag. That leaves a window in which the repository has no `dev` release, and a transient API failure inside it strands the repository there.

Within four days of the rollout this affected three repositories:

| Repository | Date | Cause | Effect |
|---|---|---|---|
| KDRTracker | 2026-08-13 | GitHub API `HTTP 502` | No `dev` release at all for roughly a day |
| Conquest-Recipes | 2026-08-13 | the same 502 incident | Stale `dev` build |
| SimpleSkills | 2026-08-12 | Maven Central `429` | Stale `dev` build |

Publishing is now attempted up to three times with a growing delay, each attempt starting from the delete so a half-finished attempt cannot wedge the retry. An exhausted retry fails the run explicitly.

## One-JAR assertion

DPM installs the first `.jar` asset it finds on the release, so a release carrying two JARs would make the installed build depend on asset order. The other repositories already assert the count; this one did not.

## Verification

The publish block was extracted and exercised in a shell against a stubbed `gh`:

- `gh` fails twice → recovers on the third attempt, exits 0
- two JARs present → `Expected exactly one JAR to publish, found 2: …`, exits 1

The hardening is already merged and confirmed live on KDRTracker, where the post-merge run published `dev-4ecce1d` matching `main` HEAD, as a prerelease with exactly one JAR.

---

_drafted by Claude on behalf of Daniel Stephenson_
