### PR TITLE
Restore main's test compilation by passing EntityInteractionProtection in PlayerQuitListenerTest

### DIFF
--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerQuitListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerQuitListenerTest.kt
@@ -164,8 +164,10 @@ class PlayerQuitListenerTest {
 
     @Test
     fun onPlayerQuit_ShouldDropRetainedEntityNotificationStateOnTheServerThread() {
-        // Arrange
+        // Arrange - the UUID is read up front rather than inside the verify() argument list, so that
+        // no invocation on another mock is made while verification mode is armed
         `when`(playerService.getPlayer(fixture.player)).thenReturn(fixture.mfPlayer)
+        val playerUuid = fixture.player.uniqueId
 
         // Act
         uut.onPlayerQuit(fixture.event)
@@ -173,7 +175,7 @@ class PlayerQuitListenerTest {
         // Assert - the retained notification is keyed on the player's UUID, so it has to be dropped
         // before the listener returns, or a reconnecting player inherits the de-duplication window
         // that was open when they left
-        verify(entityInteractionProtection).forgetPlayer(fixture.player.uniqueId)
+        verify(entityInteractionProtection).forgetPlayer(playerUuid)
     }
 
     @Test

--- a/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerQuitListenerTest.kt
+++ b/src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerQuitListenerTest.kt
@@ -38,6 +38,7 @@ class PlayerQuitListenerTest {
     private lateinit var plugin: MedievalFactions
     private lateinit var playerService: MfPlayerService
     private lateinit var interactionService: MfInteractionService
+    private lateinit var entityInteractionProtection: EntityInteractionProtection
     private lateinit var teleportService: MfTeleportService
     private lateinit var logger: Logger
     private lateinit var config: FileConfiguration
@@ -55,7 +56,8 @@ class PlayerQuitListenerTest {
         mockLogger()
         mockScheduler()
         `when`(playerService.save(anyMfPlayer())).thenReturn(Success(fixture.mfPlayer))
-        uut = PlayerQuitListener(plugin)
+        entityInteractionProtection = mock(EntityInteractionProtection::class.java)
+        uut = PlayerQuitListener(plugin, entityInteractionProtection)
     }
 
     @Test
@@ -158,6 +160,20 @@ class PlayerQuitListenerTest {
         assertEquals(fixture.playerId, saved.id)
         assertEquals(20.0, saved.power)
         assertEquals(20.0, saved.powerAtLogout)
+    }
+
+    @Test
+    fun onPlayerQuit_ShouldDropRetainedEntityNotificationStateOnTheServerThread() {
+        // Arrange
+        `when`(playerService.getPlayer(fixture.player)).thenReturn(fixture.mfPlayer)
+
+        // Act
+        uut.onPlayerQuit(fixture.event)
+
+        // Assert - the retained notification is keyed on the player's UUID, so it has to be dropped
+        // before the listener returns, or a reconnecting player inherits the de-duplication window
+        // that was open when they left
+        verify(entityInteractionProtection).forgetPlayer(fixture.player.uniqueId)
     }
 
     @Test


### PR DESCRIPTION
Closes #2022

<!-- gardener-tend-dispatch -->

## What was wrong

`main` has not compiled its test sources since b3e457d4 (2026-08-22), the merge of #2001. The `Build` check has been red on `main` for five days, and every pull request opened against `main` since then inherits that failure as a required check unrelated to its own changes.

```
e: src/test/kotlin/com/dansplugins/factionsystem/listener/PlayerQuitListenerTest.kt: (58, 40): No value passed for parameter 'entityInteractionProtection'
```

It is a semantic merge conflict between two changes with no file in common, which is why no conflict was reported and neither branch's own CI could have caught it:

- #2016 (a50d558f, 2026-08-16) added `PlayerQuitListenerTest.kt`, constructing the listener as `PlayerQuitListener(plugin)`.
- #2001 (b3e457d4, 2026-08-22) added a second constructor parameter, `entityInteractionProtection`. That branch was cut before the test file existed, so the call site was never updated.

Only test sources are affected — the main source set still compiles, which is why `Dev Release` reported success on the same commit and the published `dev` JAR is not itself broken. The cost is a blind spot rather than a shipped defect: the suite has been unrunnable, so a regression in any of the 580-plus tests would have gone unnoticed during that window.

## What was changed

- A mocked `EntityInteractionProtection` is created in `setUp` and passed to the listener under test. `mockito-inline` is already on the test classpath, so the final Kotlin class is mockable without production changes.
- One test is added, asserting that `forgetPlayer` is called with the quitting player's UUID before the listener returns. That call was added by #2001 and had no coverage; wiring the collaborator in as a mock is what makes asserting it cheap, so it is done here rather than deferred.

No production code is touched by this changeset. No user-facing behaviour changes, so no `CHANGELOG.md` entry is added.

## Data safety

No schema migration, no DPC contract change, no `config.yml` default change, no `plugin.yml` change, no `lang/` change. The diff is confined to one test file.

## What was deliberately left out

The rest of the open backlog is deferred, since one unit of work is taken per cycle and restoring a red required check on `main` was ranked ahead of everything else available. Specifically:

- #2020 (`MfFactionMapCommand` reads `sender.world` off the main thread) — ready to implement and appropriately scoped, but folding an unrelated bug fix into a build-unblocking change would delay the latter behind the review of the former.
- #2015 (duplicate `### Fixed` sections in `CHANGELOG.md`) — that issue explicitly asks for the move to be made on its own branch, since the relocated paragraphs would bury whatever else the branch contains. Honoured here rather than folded in.
- #2021 (`MfDuelAcceptCommand` reads both players' health off the main thread) — blocked on a maintainer decision about which health a duel is meant to restore, as recorded on the issue.
- #2018 (`DEPLOY_BRANCH` pinned to a deleted branch) — modifies `.github/workflows`, which is on this loop's do-not-auto-merge list and wants a human.

## Test plan

- [x] `./gradlew compileTestKotlin` — fails on `main` at b3e457d4, passes on this branch.
- [x] `./gradlew clean test` — `BUILD SUCCESSFUL`, whole suite green. This is the first passing full run since 2026-08-22.
- [x] `./gradlew lintKotlin` — `BUILD SUCCESSFUL`.
- [x] The new `forgetPlayer` assertion was empirically confirmed to fail without the production behaviour: removing the `entityInteractionProtection.forgetPlayer(...)` line from `PlayerQuitListener` locally produced `8 tests completed, 1 failed` with `WantedButNotInvoked` at `PlayerQuitListenerTest.kt:176`, and restoring it returned the class to green. The production file is unmodified in this changeset.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).

---

_drafted by Claude on behalf of Daniel Stephenson_
